### PR TITLE
Add babelify and update `gulp js` task

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,28 +1,35 @@
 {
-    "env": {
-        "es6": true,
-        "node": true
-    },
-    "extends": "airbnb-base",
-    "parserOptions": {
-        "ecmaVersion": 6,
-        "sourceType": "module",
-        "ecmaFeatures": {
-            "modules": true
-        }
-    },
-    "rules": {
-        "arrow-body-style": ["error", "always"],
-        "arrow-parens": ["error", "always"],
-        "arrow-spacing": "error",
-        "comma-dangle": ["error", "never"],
-        "complexity": ["error", 15],
-        "import/imports-first": ["error", "absolute-first"],
-        "indent": ["error", 4, { "SwitchCase": 1 }],
-        "max-len": ["error", 120, 4],
-        "max-statements": ["error", 15],
-        "no-console": 0,
-        "no-param-reassign": ["error", { "props": false }],
-        "object-shorthand": ["error", "always"]
+  "env": {
+    "es6": true,
+    "node": true
+  },
+  "extends": "airbnb-base",
+  "parserOptions": {
+    "ecmaVersion": 6,
+    "sourceType": "module",
+    "ecmaFeatures": {
+      "modules": true
     }
+  },
+  "rules": {
+    "arrow-body-style": ["error", "always"],
+    "arrow-parens": ["error", "always"],
+    "arrow-spacing": "error",
+    "comma-dangle": ["error", "never"],
+    "complexity": ["error", 15],
+    "import/imports-first": ["error", "absolute-first"],
+    "indent": ["error", 4, { "SwitchCase": 1 }],
+    "max-len": ["error", 120, 4],
+    "max-statements": ["error", 15],
+    "no-console": 0,
+    "no-param-reassign": ["error", { "props": false }],
+    "object-shorthand": ["error", "always"]
+  },
+  "settings": {
+    "import/resolver": {
+      "node": {
+        "paths": ["src"]
+      }
+    }
+  }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to
 * nunjucks package
 * nunjucks-markdown package
 * through2 package
+* babelify package
 
 ### Changed
 
@@ -31,10 +32,15 @@ and this project adheres to
 * minification is managed via command line arguments and there are no longer
   `.min` files output
 * disable file minification with `--nomin` command line argument
+* update `gulp js` to use `babelify` to allow for ES6 style authoring `import`
+* remove `gulp-cache` from html and js tasks
 
 ### Fixed
 
 * sasslint task now uses `gulp-sass-lint` and pipeline configuration correctly
+* files made for inline during `gulp css` are now correctly prefixed `.inline`
+  rather than renaming all files to `inline.css` which is very confusing with
+  multiple theme files
 
 ### Removed
 

--- a/README.md
+++ b/README.md
@@ -157,9 +157,9 @@ attribute `inline` to target scripts and links for inline.
 
 ### `gulp js`
 
-Creates the master theme JS file from all JS assets and moves vendor files as
-needed. Handles concatenation, minification, sourcemaps and moving vendor files
-into place.
+Transform ES6 into browser friendly ES5 with `babelify` and `browserify`.
+Bundles are minified by default. If the command line argument `--nomin` is set
+minification will be disabled and sourcemap support will be enabled.
 
 ### `gulp lint`
 

--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -54,7 +54,7 @@ const cssTask = () => {
             rootPath = `${rootPath}/`;
             return stream.pipe(replace('../img/', `${rootPath}img/`));
         }))
-        .pipe(rename({ basename: 'inline' }))
+        .pipe(rename({ suffix: '.inline' }))
         .pipe(plumber.stop())
         .pipe(gulp.dest(globs.to.dist))
         .pipe(browserSync.stream({ once: true }))

--- a/gulp/tasks/html.js
+++ b/gulp/tasks/html.js
@@ -11,7 +11,6 @@
 
 import browserSync from 'browser-sync';
 import gulp from 'gulp';
-import cache from 'gulp-cached';
 import htmlmin from 'gulp-htmlmin';
 import notify from 'gulp-notify';
 import plumber from 'gulp-plumber';
@@ -25,7 +24,6 @@ const htmlTask = () => {
     return gulp
         .src(globs.to.html, { base: globs.to.src })
         .pipe(plumber(errorHandler))
-        .pipe(cache('html'))
         .pipe(special())
         .pipe(commandLineArguments.nomin
             ? through.obj()

--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -2,7 +2,7 @@
 //   Task: js
 // -------------------------------------
 //
-// - cache files for `watch`
+// - Babelify ES6 into ES5
 // - Browserify theme JS bundles
 // - add sourcemaps back to original JS files for error debugging
 // - create minifed and compressed version of file (no more sourcemaps)
@@ -10,11 +10,11 @@
 //
 // -------------------------------------
 
+import babelify from 'babelify';
 import browserify from 'browserify';
 import browserSync from 'browser-sync';
 import fancyLog from 'fancy-log';
 import gulp from 'gulp';
-import cache from 'gulp-cached';
 import buffer from 'gulp-buffer';
 import flatmap from 'gulp-flatmap';
 import notify from 'gulp-notify';
@@ -31,30 +31,35 @@ const jsTask = () => {
         gulp
             .src(globs.to.js)
             .pipe(plumber(errorHandler))
-            .pipe(cache('js'))
             .pipe(flatmap((stream, file) => {
                 fancyLog(`bundling ${file.path}`);
                 // replace file contents with browserify's bundle stream
-                const bundler = browserify(file.path, {
+                file.contents = browserify(file.path, {
+                    paths: globs.to.src,
                     debug: true
-                }).bundle();
-                file.contents = bundler;
+                })
+                    .transform(babelify)
+                    .bundle();
                 return stream;
             }))
             // transform streaming contents into buffer contents
             .pipe(buffer())
-            .pipe(sourcemaps.init())
-            .pipe(sourcemaps.write({
-                includeContent: false,
-                sourceRoot: globs.to.src
-            }))
+            .pipe(commandLineArguments.nomin
+                ? sourcemaps.init({ loadMaps: true })
+                : through.obj())
             .pipe(commandLineArguments.nomin ? through.obj() : uglify())
+            .pipe(commandLineArguments.nomin
+                ? sourcemaps.write({
+                    includeContent: false,
+                    sourceRoot: globs.to.src
+                })
+                : through.obj())
             .pipe(plumber.stop())
             .pipe(gulp.dest(globs.to.dist))
             .pipe(browserSync.stream({ once: true }))
             .pipe(notify({ message: 'js task complete', onLast: true }))
     );
 };
-jsTask.description = 'bundle js, add source maps, create .min file';
+jsTask.description = 'transform ES6, bundle js, minify OR add source maps';
 
 export default jsTask;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1221,6 +1221,11 @@
         "to-fast-properties": "1.0.3"
       }
     },
+    "babelify": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/babelify/-/babelify-8.0.0.tgz",
+      "integrity": "sha512-xVr63fKEvMWUrrIbqlHYsMcc5Zdw4FSVesAHgkgajyCE1W8gbm9rbMakqavhxKvikGYMhEcqxTwB/gQmQ6lBtw=="
+    },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",

--- a/package.json
+++ b/package.json
@@ -14,24 +14,19 @@
   },
   "license": "MIT",
   "scripts": {
-    "prettier":
-      "npm run prettier-css && npm run prettier-js && npm run prettier-json && npm run prettier-md && npm run prettier-scss",
-    "prettier-css":
-      "prettier --tab-width 4 --print-width 80 --single-quote --parser css --write **\\*.css !dist\\**",
-    "prettier-js":
-      "prettier-eslint --tab-width 4 --print-width 80 --single-quote --write **\\*.js !dist\\**",
-    "prettier-json":
-      "prettier --tab-width 4 --print-width 80 --parser json --write **\\*.json !dist\\**",
-    "prettier-md":
-      "prettier --tab-width 4 --print-width 80 --prose-wrap always --parser markdown --write **\\*.md !dist\\**",
-    "prettier-scss":
-      "prettier --tab-width 4 --print-width 80 --single-quote --parser scss --write **\\*.scss !dist\\**"
+    "prettier": "npm run prettier-css && npm run prettier-js && npm run prettier-json && npm run prettier-md && npm run prettier-scss",
+    "prettier-css": "prettier --tab-width 4 --print-width 80 --single-quote --parser css --write **\\*.css !dist\\**",
+    "prettier-js": "prettier-eslint --tab-width 4 --print-width 80 --single-quote --write **\\*.js !dist\\**",
+    "prettier-json": "prettier --tab-width 4 --print-width 80 --parser json --write **\\*.json !dist\\**",
+    "prettier-md": "prettier --tab-width 4 --print-width 80 --prose-wrap always --parser markdown --write **\\*.md !dist\\**",
+    "prettier-scss": "prettier --tab-width 4 --print-width 80 --single-quote --parser scss --write **\\*.scss !dist\\**"
   },
   "dependencies": {
     "babel-core": "^6.26.0",
     "babel-eslint": "^8.2.1",
     "babel-preset-es2015": "^6.24.0",
     "babel-register": "^6.26.0",
+    "babelify": "^8.0.0",
     "beeper": "^1.1.1",
     "browser-sync": "^2.18.8",
     "browserify": "^15.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -977,6 +977,10 @@ babel-types@^6.19.0, babel-types@^6.24.1, babel-types@^6.26.0:
     lodash "^4.17.4"
     to-fast-properties "^1.0.3"
 
+babelify@^8.0.0:
+  version "8.0.0"
+  resolved "https://registry.yarnpkg.com/babelify/-/babelify-8.0.0.tgz#6f60f5f062bfe7695754ef2403b842014a580ed3"
+
 babylon@7.0.0-beta.42, babylon@^7.0.0-beta.40:
   version "7.0.0-beta.42"
   resolved "https://registry.yarnpkg.com/babylon/-/babylon-7.0.0-beta.42.tgz#67cfabcd4f3ec82999d29031ccdea89d0ba99657"


### PR DESCRIPTION
- update `gulp js` to minify OR use sourcemaps and respect `--nomin` CLI argument
- update ESLint config to resolve import from `src`
- fix `gulp css` task file naming for inline versions
- remove `gulp-cache` from html and js tasks

Fix for https://github.com/uncleSoWise/gulp-khup/issues/10.