### PR TITLE
Add SCSS sourcemaps during `--nomin` sessions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,8 @@ and this project adheres to
 * minification is managed via command line arguments and there are no longer
   `.min` files output
 * disable file minification with `--nomin` command line argument
+* enable sourcemaps for `gulp js` and `gulp css` with `--nomin` command line
+  argument
 * update `gulp js` to use `babelify` to allow for ES6 style authoring `import`
 * remove `gulp-cache` from html and js tasks
 

--- a/README.md
+++ b/README.md
@@ -4,10 +4,9 @@ A mostly reasonable gulpsheet written in ES6 modules for modest projects.
 
 ## Getting Started
 
-* be sure node, npm, yarn and gulp-cli are installed
-* run `npm install` or `yarn` to install all required packages for development
-* run `gulp` to build a new project and load the watch tasks
-* code stuff and let gulp do the grunt work for you
+* be sure `node`, `npm`, `yarn` and `gulp-cli` are installed
+* run `npm i` or `yarn` to install all required packages for development
+* run `gulp` to `build` a new project and load the `watch` task
 
 ## Directory Structure / Scaffolding
 
@@ -50,9 +49,9 @@ arguments include:
 
 * `--nobs` or `--nobrowsersync` to disable Browser Sync
 * `--nomin` to disable minification of CSS, JS and HTML output files
-* `--psi "[url]"` to test a URL with Page Speed Insights
 * `--ftp` to enable deployment via FTP
 * `--sftp` to enable deployment via SFTP
+* `--url "[url]"` to test a URL with Page Speed Insights in `gulp psi` task
 
 ### /gulp/errorHandler.js
 
@@ -102,7 +101,7 @@ action with `gulp watch` and get to coding.
 
 Every defined task listed by terminal command and a brief description.
 
-**NOTE:**Some tasks may contain sub-routines that are not explicitly expressed
+**NOTE:** Some tasks may contain sub-routines that are not explicitly expressed
 here.
 
 ### `gulp`
@@ -124,12 +123,11 @@ Deletes `/dist/` completely. Scorched earth. Only the directory itself remains.
 
 Builds the main stylesheet from the SCSS project files. Runs the CSS through
 Autoprefixer to manage browser vendor prefixes. Images less than 8kb are base64
-inlined. PX units are converted to REM units. A minified version is created
-along side the working version. A third version for use with inline style blocks
-is also created. All three files are moved into place in `/dist/`.
+inlined. PX units are converted to REM units. An inline style block version is
+created along side the working version. Files are moved into place in `/dist/`.
 
-A CSS browser reset is created from `normalize.css` and built into the
-`reset.scss` partial in `/src/`.
+If the command line argument `--nomin` is set minification will be disabled and
+sourcemap support will be enabled.
 
 ### `gulp deploy` or `gulp d`
 

--- a/gulp/tasks/css.js
+++ b/gulp/tasks/css.js
@@ -25,6 +25,7 @@ import pxtorem from 'gulp-pxtorem';
 import rename from 'gulp-rename';
 import replace from 'gulp-replace';
 import sass from 'gulp-sass';
+import sourcemaps from 'gulp-sourcemaps';
 import path from 'path';
 import through from 'through2';
 import commandLineArguments from '../commandLineArguments';
@@ -35,7 +36,14 @@ const cssTask = () => {
     return gulp
         .src(globs.to.scss, { base: globs.to.src })
         .pipe(plumber(errorHandler))
+        .pipe(commandLineArguments.nomin ? sourcemaps.init() : through.obj())
         .pipe(sass())
+        .pipe(commandLineArguments.nomin
+            ? sourcemaps.write({
+                includeContent: false,
+                sourceRoot: globs.to.src
+            })
+            : through.obj())
         .pipe(autoprefixer(['last 2 versions']))
         .pipe(pxtorem())
         .pipe(base64({

--- a/gulp/tasks/js.js
+++ b/gulp/tasks/js.js
@@ -47,13 +47,13 @@ const jsTask = () => {
             .pipe(commandLineArguments.nomin
                 ? sourcemaps.init({ loadMaps: true })
                 : through.obj())
-            .pipe(commandLineArguments.nomin ? through.obj() : uglify())
             .pipe(commandLineArguments.nomin
                 ? sourcemaps.write({
                     includeContent: false,
                     sourceRoot: globs.to.src
                 })
                 : through.obj())
+            .pipe(commandLineArguments.nomin ? through.obj() : uglify())
             .pipe(plumber.stop())
             .pipe(gulp.dest(globs.to.dist))
             .pipe(browserSync.stream({ once: true }))


### PR DESCRIPTION
- add sourcemaps to `gulp css` during `--nomin` sessions
- tidy `gulp js` pipe short circuits for `--nomin`

Fix for https://github.com/uncleSoWise/gulp-khup/issues/16.