### PR TITLE
docs: Phase 1 Task 2 — close [Unreleased] as v0.1.1 in CHANGELOG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,8 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [0.1.1] - 2026-07-16
+
 ### Added
 
 -   `.browserlistrc`
@@ -45,6 +47,21 @@ and this project adheres to
 -   files made for inline during `gulp css` are now correctly prefixed `.inline`
     rather than renaming all files to `inline.css` which is very confusing with
     multiple theme files
+-   resolved critical `@babel/traverse` vulnerability GHSA-67hx-6x53-jw92
+    (arbitrary code execution) via lockfile update
+-   resolved high `@babel/core` vulnerability GHSA-4x5r-pxfx-6jf8
+    (arbitrary file read via sourceMappingURL) via lockfile update
+-   resolved high `acorn` vulnerability GHSA-6chw-6frg-f759 (ReDoS)
+    via lockfile update
+-   resolved 51 additional moderate/high transitive vulnerabilities via
+    `npm audit fix`
+
+### Known Issues
+
+-   163 vulnerabilities remain; all require Phase 2 major-version dependency
+    upgrades (gulp v5, browser-sync v3, gulp-sass v6, psi v4, gulp-imagemin v9)
+-   `node-sass` does not compile on Node v18+; the stack requires
+    `--ignore-scripts` on modern Node. Full remediation is Phase 2.
 
 ### Removed
 


### PR DESCRIPTION
## What This PR Does

Closes the long-running `[Unreleased]` section in `CHANGELOG.md` as `v0.1.1`, dated 2026-07-16. Covers all accumulated changes since `0.1.0` (October 2017).

## Changes

- All previous `[Unreleased]` entries moved under `[0.1.1] - 2026-07-16`
- Added `### Fixed` entries documenting the security fixes from PR #22
- Added `### Known Issues` section documenting the 163 remaining vulnerabilities and `node-sass` Node v18+ incompatibility — these are Phase 2 work items

## Checklist

- [x] `[Unreleased]` section left empty and ready for future entries
- [x] Security fixes from PR #22 referenced by CVE advisory ID
- [x] Known issues documented with Phase 2 remediation path
- [x] No code changes — documentation only