### PR TITLE
test: Phase 2 Task 6 — 100% src/ coverage, 78 tests passing

### DIFF
--- a/src/scaffold.js
+++ b/src/scaffold.js
@@ -41,9 +41,10 @@ export async function scaffold({
   projectType = 'web',
   outDir,
   cwd = process.cwd(),
+  _templatesDir, // optional test seam — defaults to the bundled templates/
 }) {
   const targetDir = outDir ?? join(cwd, projectName);
-  const templatesDir = join(__dirname, '../templates');
+  const templatesDir = _templatesDir ?? join(__dirname, '../templates');
   const tokens = {
     appName: projectName,
     appDescription: description,

--- a/test/cli-prompt.test.js
+++ b/test/cli-prompt.test.js
@@ -1,0 +1,97 @@
+// Tests for the promptUser function in cli.js.
+// @clack/prompts is mocked — these tests verify the integration wiring
+// (intro called, group called with correct shape, cancel + exit on Ctrl-C)
+// without requiring an actual terminal.
+
+import { vi, describe, it, expect, afterEach } from 'vitest';
+
+vi.mock('@clack/prompts', () => ({
+  intro: vi.fn(),
+  group: vi.fn(),
+  cancel: vi.fn(),
+  outro: vi.fn(),
+  text: vi.fn().mockResolvedValue('mocked-text'),
+  select: vi.fn().mockResolvedValue('web'),
+  log: { step: vi.fn(), error: vi.fn() },
+}));
+
+import { promptUser } from '../src/cli.js';
+import * as p from '@clack/prompts';
+
+const mockValues = {
+  projectName: 'my-project',
+  description: 'A test project',
+  authorName: 'Test Author',
+  authorEmail: 'test@example.com',
+  projectType: 'web',
+};
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe('promptUser', () => {
+  it('calls p.intro with the package name', async () => {
+    p.group.mockResolvedValueOnce(mockValues);
+    await promptUser('');
+    expect(p.intro).toHaveBeenCalledWith('create-gulp-khup');
+  });
+
+  it('calls p.group to collect project details', async () => {
+    p.group.mockResolvedValueOnce(mockValues);
+    await promptUser('');
+    expect(p.group).toHaveBeenCalledOnce();
+  });
+
+  it('returns the values from p.group', async () => {
+    p.group.mockResolvedValueOnce(mockValues);
+    const result = await promptUser('');
+    expect(result).toEqual(mockValues);
+  });
+
+  it('passes initialName as initialValue for the projectName prompt', async () => {
+    p.group.mockResolvedValueOnce(mockValues);
+    await promptUser('pre-filled-name');
+
+    // p.group is called with (fieldsObject, options)
+    // The fields object is the first arg — each field is a function
+    const [fieldsObj] = p.group.mock.calls[0];
+    expect(typeof fieldsObj.projectName).toBe('function');
+  });
+
+  it('invokes all field functions and calls p.text / p.select for each prompt', async () => {
+    // Make p.group actually invoke the field functions — this covers the
+    // arrow function bodies inside the group call (lines 54-85 in cli.js)
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      for (const fn of Object.values(fieldsObj)) {
+        await fn();
+      }
+      return mockValues;
+    });
+
+    await promptUser('my-project');
+
+    // p.text called for projectName, description, authorName, authorEmail (4×)
+    expect(p.text).toHaveBeenCalledTimes(4);
+    // p.select called for projectType (1×)
+    expect(p.select).toHaveBeenCalledTimes(1);
+  });
+
+  it('calls p.cancel and process.exit(0) when onCancel is triggered', async () => {
+    // Make p.group invoke the onCancel callback to simulate Ctrl-C
+    p.group.mockImplementationOnce(async (_fields, { onCancel }) => {
+      onCancel();
+    });
+
+    const exitSpy = vi.spyOn(process, 'exit').mockImplementation(() => {
+      throw new Error('process.exit called');
+    });
+
+    await expect(promptUser('')).rejects.toThrow('process.exit called');
+
+    expect(p.cancel).toHaveBeenCalledWith('Cancelled — no files were created.');
+    expect(exitSpy).toHaveBeenCalledWith(0);
+
+    exitSpy.mockRestore();
+  });
+});

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -7,6 +7,14 @@ import { validateProjectName, sanitizeProjectName, getGitConfig } from '../src/c
 // ---------------------------------------------------------------------------
 
 describe('validateProjectName', () => {
+  it('returns an error message for null input', () => {
+    expect(validateProjectName(null)).toMatch(/required/i);
+  });
+
+  it('returns an error message for undefined input', () => {
+    expect(validateProjectName(undefined)).toMatch(/required/i);
+  });
+
   it('returns an error message for empty string', () => {
     expect(validateProjectName('')).toMatch(/required/i);
   });

--- a/test/scaffold-errors.test.js
+++ b/test/scaffold-errors.test.js
@@ -1,0 +1,83 @@
+// Edge-case tests for error re-throw paths in scaffold.js.
+// These tests cover the branches that require specific error conditions
+// and use filesystem tricks or the _templatesDir test seam — no vi.mock needed.
+
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdtemp, mkdir, writeFile, rm, access } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+import { scaffold } from '../src/scaffold.js';
+
+const defaults = {
+  projectName: 'test-project',
+  description: 'A test project',
+  authorName: 'Test Author',
+  authorEmail: 'test@example.com',
+  projectType: 'web',
+};
+
+describe('scaffold — mkdir error re-throw (lines 62-63)', () => {
+  // When mkdir fails with a code OTHER than EEXIST, the error is re-thrown.
+  // Trigger: pass an outDir whose parent directory does not exist.
+  // mkdir({ recursive: false }) throws ENOENT — not EEXIST — so we re-throw.
+
+  it('re-throws when mkdir fails with a non-EEXIST error', async () => {
+    await expect(
+      scaffold({
+        ...defaults,
+        outDir: '/this-parent-definitely-does-not-exist-gulp-khup/child',
+      })
+    ).rejects.toThrow(); // ENOENT from mkdir — re-thrown by scaffold
+  });
+
+  it('the re-thrown error is not the EEXIST wrapper message', async () => {
+    const err = await scaffold({
+      ...defaults,
+      outDir: '/this-parent-definitely-does-not-exist-gulp-khup/child',
+    }).catch((e) => e);
+
+    expect(err.message).not.toMatch(/already exists/i);
+  });
+});
+
+describe('scaffold — copyDir error paths (lines 75-77)', () => {
+  let tmpDir;
+  let outDir;
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gulp-khup-errors-'));
+    outDir = join(tmpDir, 'output');
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('ignores ENOENT when a type-specific template dir is missing (line 75)', async () => {
+    // _templatesDir has a base/ with one file, but no web/ subdir.
+    const tplDir = join(tmpDir, 'tpls');
+    await mkdir(join(tplDir, 'base'), { recursive: true });
+    await writeFile(join(tplDir, 'base', 'test.txt'), 'hello');
+    // web/ intentionally absent → readdir throws ENOENT → no-op (line 75 return)
+
+    await expect(
+      scaffold({ ...defaults, outDir, _templatesDir: tplDir })
+    ).resolves.toBeUndefined();
+
+    // base/test.txt was still copied
+    await expect(access(join(outDir, 'test.txt'))).resolves.toBeUndefined();
+  });
+
+  it('re-throws non-ENOENT errors from readdir (line 76)', async () => {
+    // Create a _templatesDir where 'base' is a FILE, not a directory.
+    // readdir on a file throws ENOTDIR (not ENOENT) → re-thrown by copyDir.
+    const tplDir = join(tmpDir, 'tpls');
+    await mkdir(tplDir, { recursive: true });
+    await writeFile(join(tplDir, 'base'), 'i am a file, not a directory');
+
+    await expect(
+      scaffold({ ...defaults, outDir, _templatesDir: tplDir })
+    ).rejects.toThrow(); // ENOTDIR — not ENOENT — so it propagates
+  });
+});


### PR DESCRIPTION
## What This PR Does

Phase 2 Task 6 — reaches 100% coverage on all `src/**/*.js` metrics. This is the coverage gate that must pass before `next` can merge to `develop`.

## Changes

### `src/scaffold.js`
Added one optional parameter `_templatesDir` as a test seam:
```js
export async function scaffold({ ..., _templatesDir }) {
  const templatesDir = _templatesDir ?? join(__dirname, '../templates');
```
Backwards compatible — all existing callers unaffected. Enables testing of ENOENT and non-ENOENT error paths without mocking `fs/promises`.

### `test/scaffold-errors.test.js` (new — 4 tests)

| Test | What it covers | Technique |
|------|---------------|-----------|
| re-throws non-EEXIST mkdir error | lines 62-63 in scaffold.js | Pass outDir with non-existent parent (`ENOENT` ≠ `EEXIST` → re-throws) |
| error is not the EEXIST wrapper message | branch distinction | Same setup |
| ENOENT in copyDir ignored | line 75 | `_templatesDir` with no web/ subdir → `ENOENT` → silent return |
| re-throws non-ENOENT readdir error | line 76 | `_templatesDir` where 'base' is a FILE → `readdir` throws `ENOTDIR` → re-throws |

### `test/cli-prompt.test.js` (updated — +1 test)
New test makes `p.group` actually invoke all 5 field functions, covering the arrow function bodies inside the `group({...})` call (lines 54–85). `p.text` and `p.select` now have `mockResolvedValue` defaults so invocation doesn't throw.

### `test/cli.test.js` (updated — +2 tests)
Added `validateProjectName(null)` and `validateProjectName(undefined)` — covers the `name ?? ''` nullish coalescing branch (line 8).

## Final Coverage

```
 src          |     100 |      100 |     100 |     100 |
  cli.js      |     100 |      100 |     100 |     100 |
  scaffold.js |     100 |      100 |     100 |     100 |
```

## Test Results

```
✓ test/package.test.js        (10 tests)
✓ test/bin.test.js             (6 tests)
✓ test/scaffold-errors.test.js (4 tests)
✓ test/cli.test.js            (26 tests)
✓ test/cli-prompt.test.js      (6 tests)
✓ test/scaffold.test.js       (26 tests)

Test Files  6 passed (6)
     Tests  78 passed (78)
src/ coverage: 100% lines / 100% branches / 100% functions / 100% statements
```

## Checklist

- [x] 78 tests passing, 0 skipped
- [x] `src/` 100% lines, branches, functions, statements
- [x] No mocking of `fs/promises` — error paths triggered via real filesystem conditions
- [x] `_templatesDir` parameter backwards compatible (defaults to bundled `templates/`)
- [x] `npm run test:coverage` exits 0