### PR TITLE
chore: Phase 2 Tasks 7–9 — publish workflow, README, AGENTS.md, copilot-instructions

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -1,70 +1,52 @@
-# Copilot Instructions for gulp-khup
+# Copilot Instructions for create-gulp-khup
 
 ## What This Repo Is
 
-gulp-khup is a Gulp 4 gulpsheet being modernized into a `create-gulp-khup` npm scaffolder.
-See `AGENTS.md` for architecture overview, `TODO.md` for roadmap, and
-`docs/superpowers/specs/2026-07-15-gulp-khup-modernization-design.md` for the full design.
+`create-gulp-khup` (repo: `gulp-khup`) is a `create-*` npm scaffolder that generates
+Gulp 5 static-site projects via `npm create gulp-khup@latest my-project`.
 
-## Gulp Task File Pattern
+## Scaffolder Conventions
 
-Every file in `gulp/tasks/` follows this exact structure:
+### Module System
+- Native ESM (`"type": "module"`) — `import`/`export` everywhere, no `require()`
+- No build step — `src/`, `bin/`, and `templates/` are published as-is
 
-```js
-// -------------------------------------
-//   Task: taskName
-// -------------------------------------
-//
-// - describe what this task does
-//
-// -------------------------------------
+### Template Files
+- Template files have `.tpl` extension in `templates/`
+- Token syntax: `<%= tokenName %>` (camelCase names)
+- Current tokens: `appName`, `appDescription`, `authorName`, `authorEmail`, `appVersion`, `year`
+- Non-`.tpl` files are copied verbatim
 
-import dependency from 'package';
-import gulp from 'gulp';
-import plumber from 'gulp-plumber';
-import commandLineArguments from '../commandLineArguments';
-import errorHandler from '../errorHandler';
-import globs from '../globs';
+### File Operations
+- Use Node.js built-in `fs/promises` — do NOT add `fs-extra` or similar
+- Use `mkdtemp` in tests for temp directories; always clean up in `afterEach`
+- Use `_templatesDir` parameter in scaffold() to test with custom template directories
 
-const taskName = () => {
-  return gulp
-    .src(globs.to.someGlob)
-    .pipe(plumber(errorHandler))
-    // ... pipeline steps
-    .pipe(gulp.dest(globs.to.dist));
-};
+### Prompts
+- Use `@clack/prompts` — do NOT use `inquirer`, `readline`, or `prompts`
+- Ctrl+C must exit cleanly with a message, never a stack trace
 
-export default taskName;
-```
+## Testing Rules
+- Vitest only — do NOT use Jest
+- Write failing test FIRST (TDD)
+- `src/**/*.js` requires 100% coverage (enforced in CI via `npm run test:coverage`)
+- Any exclusion from thresholds requires a comment in vitest.config.js with rationale
+- Scaffold tests: use `mkdtemp` + `afterEach(() => rm(tmpDir, { recursive: true }))`
+- Never leave temp directories behind
+- Mock `@clack/prompts` in cli-prompt tests — do NOT mock `fs/promises`
 
-## Hard Rules
+## Template Task Conventions (Generated Projects)
 
-- **All paths via `globs.js`** — never hardcode `/src/`, `/dist/`, or any file path in a task file
-- **All pipelines use `plumber(errorHandler)`** — without this, a compile error kills the watch
-- **CLI flags from `commandLineArguments.js`** — never read `process.argv` directly in tasks
-- **No `require()`** — this codebase is ESM-via-Babel; use `import` throughout
-- **No breaking dep bumps in Phase 1** — security fixes only via `npm audit fix`
-- **Always use `--ignore-scripts`** — `node-sass` does not compile on Node v18+
-
-## Phase 2 Conventions (for `next` branch work)
-
-When working on Phase 2 (the scaffolder), the module system changes to native ESM
-(`"type": "module"` in package.json). Conventions shift:
-
-- `@clack/prompts` for all interactive CLI prompts — no `readline` or `inquirer`
-- `fs/promises` (built-in) for all file operations — no `fs-extra`
-- Template files use `.tpl` extension with `<%= tokenName %>` substitution syntax
-- Vitest for all tests — write failing test first, then implement
-- 100% line coverage is required before merging to `main`/`develop`
-
-## Dependency Constraints
-
-Phase 1 (current `develop`): Do NOT bump Gulp past 4.x, do NOT add ESM-only packages.
-Phase 2 (`next` branch): Full modernisation — Gulp 5, esbuild, Biome, Dart Sass.
+When editing files inside `templates/`:
+- Gulp 5 tasks: `export default taskFn` — no `gulp.task('name', fn)` string form
+- All file paths from `globs.js` — never hardcode paths in task files
+- All `gulp.src()` pipelines use `.pipe(plumber(errorHandler))`
+- JS: esbuild (not Browserify)
+- CSS: Dart Sass via `gulp-sass` v6 + `sass` package
+- Linting: Biome (not ESLint/Prettier)
 
 ## PR Requirements
-
-- `npm install --ignore-scripts` completes without error
-- `npm audit --audit-level=high` — document any that can't be resolved without Phase 2
-- CHANGELOG.md updated for any user-facing change
-- Phase 2 PRs additionally require: all Vitest tests pass, coverage must not drop
+- `npm test` passes (78 tests, 0 skipped)
+- `npm run test:coverage` exits 0 (100% src/ coverage)
+- `npm audit --audit-level=high` exits 0 (0 vulnerabilities)
+- CHANGELOG.md updated for user-facing changes

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,7 @@ jobs:
         run: npm install --ignore-scripts --legacy-peer-deps
 
       - name: Run security audit
-        # Informational only — 163 remaining vulns all require Phase 2 breaking changes.
-        # We audit but do not fail the build on high/critical until Phase 2 is merged.
+        # 163 remaining vulns all require Phase 2 breaking changes — informational only.
         run: npm audit || true
 
   test:
@@ -43,5 +42,6 @@ jobs:
 
       - name: Run tests
         run: npm test
-        # Note: `npm test` is a no-op in Phase 1 (no test suite yet).
-        # This job becomes meaningful after Phase 2 adds Vitest.
+
+      - name: Run coverage (src/ must be 100%)
+        run: npm run test:coverage

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to npm
+
+on:
+  release:
+    types: [published]
+
+jobs:
+  publish:
+    name: npm publish
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
+
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '20'
+          registry-url: 'https://registry.npmjs.org'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests
+        run: npm test
+
+      - name: Verify 100% src/ coverage
+        run: npm run test:coverage
+
+      - name: Publish to npm
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,77 +4,76 @@ Instructions for AI agents contributing to this repository.
 
 ## Repository Overview
 
-**gulp-khup** is a Gulp 4 gulpsheet (starter template) for static marketing/agency site
-projects. It is being modernized into a `create-gulp-khup` npm scaffolder — see `TODO.md`
-and `docs/superpowers/specs/` for the full roadmap.
+**create-gulp-khup** (repo: `gulp-khup`) is a `create-*` npm scaffolder that generates
+Gulp 5 static-site projects. Run `npm create gulp-khup@latest my-project` to scaffold.
 
-## Current Architecture (v0.1.1)
+## Architecture
 
 ```
-gulpfile.babel.js         # Entry point — registers all gulp tasks via @babel/register
-gulp/
-  commandLineArguments.js # CLI flag parsing: --nomin, --nobs, --ftp, --sftp, --url
-  errorHandler.js         # Common plumber error handler — prevents watch crashes
-  globs.js                # All file path globs (single source of truth for paths)
-  tasks/
-    build.js              # Series: clean → nunjucks → css → js → img → static → html
-    clean.js              # Deletes /dist/
-    css.js                # SCSS → CSS → autoprefixer → pxtorem → base64 → cssnano
-    default.js            # Series: build → watch
-    deploy.js             # FTP/SFTP deployment via vinyl-ftp / gulp-sftp
-    eslint.js             # ESLint on JS source files
-    html.js               # Copy + minify HTML from /src/
-    img.js                # Compress images with gulp-imagemin
-    inline.js             # Inline critical CSS/JS into HTML
-    js.js                 # Browserify + Babel ES6 → ES5 → uglify
-    lint.js               # Series: eslint + sasslint
-    nunjucks.js           # Render Nunjucks templates from /src/templates/
-    prettier.js           # Run Prettier on source files
-    psi.js                # PageSpeed Insights test (requires --url flag)
-    sasslint.js           # Sass linting via gulp-sass-lint
-    size.js               # Report /dist/ output sizes
-    static.js             # Copy static files (fonts, etc.) to /dist/
-    watch.js              # BrowserSync dev server + file watching
+bin/
+  create.js              # CLI entry point — parses args, calls cli.js + scaffold.js
+src/
+  cli.js                 # @clack/prompts prompt flow + input validation
+  scaffold.js            # Template file copying + <%= token %> substitution
+templates/
+  base/                  # Shared Gulp 5 task suite (all project types)
+    gulpfile.js
+    package.json.tpl     # Tokens: appName, appDescription, appVersion, authorName, authorEmail
+    README.md.tpl        # Tokens: appName, appDescription, authorName
+    CHANGELOG.md.tpl     # Tokens: appName, year
+    gulp/tasks/          # build, clean, css, deploy, html, img, inline, nunjucks, size, static, watch
+  web/                   # Static HTML project additions
+    gulp/tasks/          # deploy.js, js.js, psi.js
+    src/                 # scss/, js/, img/, fonts/, .njk templates
+  wordpress/             # Stub — coming soon
+  email/                 # Stub — coming soon
+test/
+  package.test.js        # Validates create-gulp-khup package.json structure
+  scaffold.test.js       # Generated file existence, content, token substitution, snapshots
+  scaffold-errors.test.js # Error re-throw paths: non-EEXIST mkdir, non-ENOENT readdir
+  cli.test.js            # validateProjectName, sanitizeProjectName, getGitConfig
+  cli-prompt.test.js     # promptUser mocked with @clack/prompts
+  bin.test.js            # Structural assertions on bin/create.js
 ```
 
 ## Key Commands
 
 ```bash
-npm install --ignore-scripts   # Install (--ignore-scripts required on Node v18+)
-gulp                           # Default: build + watch (full workflow)
-gulp build                     # Full build only
-gulp watch                     # Watch only (project must already be built)
-gulp css                       # CSS pipeline only
-gulp js                        # JS pipeline only
-gulp img                       # Image optimisation only
-gulp lint                      # Run eslint + sasslint
-gulp deploy --ftp              # Deploy via FTP (requires .env)
-gulp deploy --sftp             # Deploy via SFTP (requires .env)
-gulp psi --url "https://…"     # PageSpeed Insights
-gulp --nomin                   # Build with sourcemaps, no minification
-gulp --nobs                    # Build without starting BrowserSync
+npm install                    # Install scaffolder dependencies
+npm test                       # Run Vitest (78 tests, 0 skipped)
+npm run test:coverage          # Run with v8 coverage — src/ must be 100%
+npm run test:watch             # Watch mode for TDD
+node bin/create.js my-project  # Run the scaffolder locally
 ```
 
 ## Conventions
 
-- **ES modules via Babel** — all `gulp/` files use `import`/`export` compiled by `@babel/register`
-- **Globs** — ALL file paths live in `gulp/globs.js`; never hardcode paths in task files
-- **Error handling** — all `gulp.src()` pipelines use `.pipe(plumber(errorHandler))`
-- **CLI arguments** — task behavior is controlled exclusively via `commandLineArguments.js` flags
-- **Commit style** — Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `refactor:`
+- **ESM throughout** — `"type": "module"`, all files use `import`/`export`
+- **No build step** — source is published as-is
+- **Template tokens** — `.tpl` files use `<%= tokenName %>` syntax (camelCase)
+- **One runtime dep** — only `@clack/prompts`; use Node.js built-ins for everything else
+- **Commit style** — Conventional Commits: `feat:`, `fix:`, `chore:`, `docs:`, `test:`
 
-## Known Environment Constraint
+## Testing Rules
 
-`node-sass` does not compile on Node v18+. Always use `npm install --ignore-scripts`
-when working with this repo on modern Node. This is fully resolved in Phase 2.
+- Framework: Vitest
+- Coverage: 100% lines/branches/functions/statements on `src/**/*.js` (enforced in CI)
+- Write failing test FIRST (TDD) — then implement minimally to pass
+- Scaffold tests: use `mkdtemp` + `afterEach` cleanup; never leave temp dirs behind
+- Use `_templatesDir` parameter in scaffold() to test with custom template directories
+- Mock `@clack/prompts` in `cli-prompt.test.js` for promptUser tests
+- `bin/create.js` is tested structurally only — interactive behaviour via smoke test
 
-## Active Roadmap
+## Template Conventions (Generated Projects)
 
-See `TODO.md` for Phase 2 work items with GitHub Issue links.
-See `docs/superpowers/specs/2026-07-15-gulp-khup-modernization-design.md` for the full design.
-See `docs/superpowers/plans/` for step-by-step implementation plans.
+When editing files inside `templates/`:
+- Gulp 5 tasks: `export default taskFn` — no `gulp.task('name', fn)` string form
+- All file paths from `globs.js` — never hardcode `/src/` or `/dist/` in task files
+- All `gulp.src()` pipelines must use `.pipe(plumber(errorHandler))`
+- JS: esbuild (not Browserify)
+- CSS: Dart Sass via `gulp-sass` v6 + `sass` package
+- Linting: Biome (not ESLint/Prettier)
 
-Phase 2 transforms this gulpsheet into a `create-gulp-khup` npm scaffolder with:
-- Gulp 5, esbuild, Dart Sass, Biome
-- `npm create gulp-khup@latest my-project` CLI
-- Full Vitest test suite with 100% line coverage
+## Roadmap
+
+See `TODO.md` and `docs/superpowers/specs/2026-07-15-gulp-khup-modernization-design.md`.

--- a/README.md
+++ b/README.md
@@ -1,282 +1,83 @@
-# gulp-khup [0.1.1]
+# create-gulp-khup
 
-A mostly reasonable gulpsheet written in ES6 modules for modest projects.
+Scaffold a Gulp 5 static-site project in seconds.
 
-> **Note:** This is the v0.1.1 maintenance release. See [TODO.md](TODO.md) for the
-> upcoming modernization into a `create-gulp-khup` npm scaffolder (Gulp 5, esbuild,
-> Dart Sass, Biome).
+```bash
+npm create gulp-khup@latest my-project
+```
+
+Or with npx:
+
+```bash
+npx create-gulp-khup my-project
+```
+
+## What Gets Generated
+
+A complete Gulp 5 project for static marketing and agency sites:
+
+```
+my-project/
+  gulpfile.js
+  package.json
+  .gitignore
+  .nvmrc
+  .env.example
+  biome.json
+  CHANGELOG.md
+  README.md
+  gulp/
+    commandLineArguments.js   # CLI flags: --nomin, --nobs, --ftp, --sftp
+    errorHandler.js           # Plumber error handler
+    globs.js                  # All file path globs
+    tasks/
+      build.js                # Full build pipeline
+      clean.js                # Delete /dist/
+      css.js                  # Dart Sass → PostCSS → cssnano
+      deploy.js               # FTP/SFTP deployment
+      html.js                 # Minify HTML
+      img.js                  # Image optimisation
+      js.js                   # esbuild JS bundling
+      nunjucks.js             # Nunjucks template rendering
+      watch.js                # BrowserSync + file watching
+      ...
+  src/
+    scss/                     # Sass source files
+    js/                       # JavaScript source
+    img/                      # Images
+    fonts/                    # Web fonts
+    *.njk                     # Nunjucks templates
+```
+
+## Generated Project Tech Stack
+
+| Concern | Tool |
+|---------|------|
+| Task runner | Gulp 5 |
+| JS bundling | esbuild |
+| CSS | Dart Sass + PostCSS + cssnano |
+| HTML templating | Nunjucks |
+| Linting / formatting | Biome |
+| Dev server | BrowserSync |
+| Deploy | ssh2-sftp-client (FTP/SFTP) |
+
+## Running the Generated Project
+
+```bash
+cd my-project
+npm install
+gulp                    # Build + watch (full workflow)
+gulp build              # Build only
+gulp --nomin            # Build with sourcemaps, no minification
+gulp deploy --ftp       # Deploy via FTP  (configure .env first)
+gulp deploy --sftp      # Deploy via SFTP (configure .env first)
+```
 
 ## Requirements
 
--   **Node.js 16** — `node-sass` (used by the CSS task) requires native compilation
-    and does not support Node 17+. Use `nvm use` to switch to the pinned version.
--   **npm 7+** or **Yarn**
--   **gulp-cli** installed globally: `npm install -g gulp-cli`
+Node.js 18 or higher is required to run `create-gulp-khup`.
+The generated project also targets Node 18+.
 
-On Node 17+ you can still install with `npm install --ignore-scripts --legacy-peer-deps`,
-but the `gulp css` task will not function. Full Node 18+ support lands in Phase 2.
+## Contributing
 
-## Getting Started
-
--   run `nvm use` to switch to the correct Node version (requires [nvm](https://github.com/nvm-sh/nvm))
--   run `npm install` to install all required packages for development
--   run `gulp` to `build` a new project and load the `watch` task
-
-## Directory Structure / Scaffolding
-
-### root
-
-Project and text-editor configuration files reside in the project repo root. The
-main `gulpfile` lives here along side the CHANGELOG, README and other essential
-config files.
-
-### /dist/
-
-Compiled code and optimized assets are built here from `/src/`. BrowserSync uses
-this directory for local development. The `watch` task looks at this directory
-and performs tasks when files change.
-
-### /gulp/
-
-All gulp tasks, config files and support files reside here.
-
-### /src/
-
-Here’s where the work is done. The files open in your text editor of choice
-should all be working in `/src/`.
-
-## Working with gulp-khup
-
-### gulpfile.babel.js
-
-The `gulpfile` is the entry point to all gulp configuration. Configuration and
-task development have been made as modular as possible.
-
-Environment-specific variables are loaded securely through `.env` which is NOT
-under version control. The `gulpfile` then loads in all the gulp tasks. Order is
-unimportant here (but alphabetical is encouraged).
-
-### /gulp/commandLineArguments.js
-
-Configure gulp tasks with the help of CLI arguments. Current supporting CLI
-arguments include:
-
--   `--nobs` or `--nobrowsersync` to disable Browser Sync
--   `--nomin` to disable minification of CSS, JS and HTML output files
--   `--ftp` to enable deployment via FTP
--   `--sftp` to enable deployment via SFTP
--   `--url "[url]"` to test a URL with Page Speed Insights in `gulp psi` task
-
-### /gulp/errorHandler.js
-
-The common error handling function should be called from the `errorHandler`
-object that is loaded from `error.js`
-
-Error messages will display without breaking the `watch` workflow zen.
-
-### /gulp/globs.js
-
-Globs and file path references should be called from the `globs` object that is
-loaded from `globs.js`.
-
-If a project requires `gulp` to be somewhere other than `root`, basic file paths
-can be updated in the variables at the top of the file which will then cascade
-down into the exported module.
-
-### .env
-
-Environment-specific variables are stored here. This file is under the
-`.gitignore` file list to prevent sensitive and secure information from being
-committed to the Git repo.
-
-Use this file to store deploy connection host settings, database information,
-usernames and passwords. By default the `deploy` task will reference this file.
-
-## Task Workflow
-
-In practice, running `gulp` should be the only command required for workflow
-zen. Gulp will build the complete project, spin up BrowserSync for local
-development and watch files.
-
-Gulp will actively watch files and run tasks accordingly on file change. If
-everything is working, the developer should only need to head back to the
-terminal to cancel the `watch` task with Ctrl+C at the end of work. Workflow zen
-is achieved with a “set it and forget it” mentality in the land of gulp.
-
-However, there are a great deal of sub-tasks that can still be called directly
-outside of this workflow. Calling tasks by name can be useful when debugging,
-while developing new features or simply for calling a specific task on demand
-for better/faster performance.
-
-**Example:** If the project is already built and waiting, jump right into the
-action with `gulp watch` and get to coding.
-
-## Task Index and Overview
-
-Every defined task listed by terminal command and a brief description.
-
-**NOTE:** Some tasks may contain sub-routines that are not explicitly expressed
-here.
-
-### `gulp`
-
-The default task can also be called with `gulp default`, but why waste the
-effort on extra characters. Calls `build` and then `watch`.
-
-### `gulp build` or `gulp b`
-
-First `/dist/` is nuked with `clean` and then the build order for tasks is
-called. Next `img`, `html`, `nunjucks`, `css`, `js`, `static` and `inline` tasks
-are all called to build a complete project to `/dist/`.
-
-### `gulp clean` or `gulp c`
-
-Deletes `/dist/` completely. Scorched earth. Only the directory itself remains.
-
-### `gulp css`
-
-Builds the main stylesheet from the SCSS project files. Runs the CSS through
-Autoprefixer to manage browser vendor prefixes. Images less than 8kb are base64
-inlined. PX units are converted to REM units. An inline style block version is
-created along side the working version. Files are moved into place in `/dist/`.
-
-If the command line argument `--nomin` is set minification will be disabled and
-sourcemap support will be enabled.
-
-### `gulp deploy` or `gulp d`
-
-Deploy complete project to server as defined by `.env` environment-specific
-variables. Uses FTP or SFTP depending on CLI arguments.
-
-### `gulp eslint`
-
-Run ESLint on JS files in `/src/`.
-
-### `gulp html`
-
-Correct special text characters erroneously copy pasted into the HTML and
-minify.
-
-### `gulp img`
-
-Losslessly compresses image assets and moves them into place. Handles JPG, PNG,
-GIF and SVG file types.
-
-### `gulp inline`
-
-Inline scripts directly into HTML for performance gains. Use boolean HTML
-attribute `inline` to target scripts and links for inline.
-
-### `gulp js`
-
-Transform ES6 into browser friendly ES5 with `babelify` and `browserify`.
-Bundles are minified by default. If the command line argument `--nomin` is set
-minification will be disabled and sourcemap support will be enabled.
-
-### `gulp lint`
-
-Run all the various linters on files in `/src/`.
-
-### `gulp nunjucks`
-
-Contains all the power of `html` but with the distinction of building `.njk`
-template files into HTML first. Converts Markdown blocks or imports via
-`{{ markdown }}` command.
-
-### `gulp prettier`
-
-Format repo files with `prettier`.
-
-### `gulp psi`
-
-Run tests with Google PageSpeed Insights. One test runs for mobile and one for
-desktop. Supply the URL to be tested via CLI argument `--url "[url]"`. The CLI
-has a limit of 5s per result set, which is better than the web interfaces 60s
-turn around time on cached results.
-
-### `gulp sasslint`
-
-Run Sass Lint on SCSS files in `/src/`.
-
-### `gulp size`
-
-Quick and dirty local performance audit. Output file size reports on `/dist/`.
-
-### `gulp static`
-
-Moves miscellaneous files from `/src/` into place in `/dist/`. This task carbon
-copies files without affecting changes. This manages root level assets such as
-configuration and icon files. Handles `/fonts/` and other theme assets by
-default.
-
-### `gulp watch` or `gulp w`
-
-Listens for changes in `/src/` and builds to `/dist/`. Listens for changes in
-`/dist/` and deploys to remote server. File transfer work is time intensive, so
-`gulp` only uploads the files in need, as needed.
-
-Configure `gulp watch` settings via CLI arguments
-
-If BrowserSync is enabled, `watch` creates a secure public URL to share your
-local sites with any Internet-connected device on the local network. Perfect for
-browser and device testing. Great for collaborative work without all the “ok hit
-refresh” chat spam back and forth.
-
-BrowserSync will manage browser refresh and device sync on file change and uses
-`/dist/` as base for the server. The terminal provides all the URLs needed for
-making use of BrowserSync. Develop using these URLs and NOT with a simple
-local-file approach.
-
-    [BS] Access URLs:
-    --------------------------------
-           Local: http://localhost:9000
-        External: http://10.1.10.235:9000
-    --------------------------------
-              UI: http://localhost:3001
-     UI External: http://10.1.10.235:3001
-    --------------------------------
-    [BS] Serving files from: dist/
-
-## Task Workflow Shortcuts
-
-The major workflow tasks come with shortcut commands for the lazy developer.
-
--   `gulp` == `gulp default`
--   `gulp b` == `gulp build`
--   `gulp c` == `gulp clean`
--   `gulp d` == `gulp deploy`
--   `gulp w` == `gulp watch`
-
-## Notes
-
-**[gulp-khup]** is written in the syntax of
-[Gulp 4.0](https://github.com/gulpjs/gulp/tree/4.0). This allows for use of some
-features like `since`, `series` and `parallel`. See the
-[GitHub page](https://github.com/gulpjs/gulp) for code examples.
-
-**[gulp-khup]** is designed to be a starting off point for projects. Some
-projects will require adding new tasks or updates to the existing tasks.
-
-## Author
-
-#### Richard Deslauriers
-
--   [twitter.com/uncleSoWise](https://twitter.com/uncleSoWise)
--   [github.com/uncleSoWise](https://github.com/uncleSoWise)
--   [bitbucket.org/uncleSoWise](https://bitbucket.org/uncleSoWise)
-
-## Helpful Resources
-
-Knowing is half the battle.
-
--   [http://gulpjs.com/](http://gulpjs.com/)
--   [https://markgoodyear.com/2014/01/getting-started-with-gulp/](https://markgoodyear.com/2014/01/getting-started-with-gulp/)
--   [http://makina-corpus.com/blog/metier/2015/make-your-gulp-modular](http://makina-corpus.com/blog/metier/2015/make-your-gulp-modular)
--   [http://moonshotproject.github.io/moondash/building/packaging/2014/11/26/modular-gulp.html](http://moonshotproject.github.io/moondash/building/packaging/2014/11/26/modular-gulp.html)
--   [https://bugsnag.com/blog/replacing-the-rails-asset-pipeline-with-gulp](https://bugsnag.com/blog/replacing-the-rails-asset-pipeline-with-gulp)
--   [http://drewbarontini.com/articles/building-a-better-gulpfile/](http://drewbarontini.com/articles/building-a-better-gulpfile/)
--   [http://macr.ae/article/splitting-gulpfile-multiple-files.html](http://macr.ae/article/splitting-gulpfile-multiple-files.html)
-
-## License
-
-MIT
+See [AGENTS.md](AGENTS.md) for AI agent guidance and [TODO.md](TODO.md) for the roadmap.


### PR DESCRIPTION
## What This PR Does

Phase 2 Tasks 7–9 — publish workflow, README rewrite, and documentation updates for the Phase 2 architecture. No source or test changes.

## Changes

### Task 7 — `.github/workflows/publish.yml` (new)
Triggered on GitHub Release publication:
1. `npm ci` — clean install
2. `npm test` — all 78 tests must pass
3. `npm run test:coverage` — `src/` must be 100%
4. `npm publish --provenance --access public` — publishes with supply chain provenance

> **Before first publish:** add `NPM_TOKEN` secret to repo Settings → Secrets and variables → Actions → New repository secret. Generate at npmjs.com → Access Tokens → Automation type.

### Task 7b — `.github/workflows/ci.yml` (updated)
- Added `npm run test:coverage` step to the `test` job — coverage thresholds are now enforced in CI, not just locally
- Audit comment cleaned up

### Task 8 — `README.md` (full rewrite)
Complete rewrite for the `create-gulp-khup` npm package:
- `npm create gulp-khup@latest my-project` as the hero command
- Generated project directory tree
- Tech stack table (Gulp 5, esbuild, Dart Sass, Biome, BrowserSync, ssh2-sftp-client)
- Running the generated project commands
- Node 18+ requirements

### Task 9 — `AGENTS.md` (full rewrite)
- Architecture section updated with test file inventory and descriptions
- Testing rules: `_templatesDir` seam, `@clack/prompts` mock pattern, temp dir cleanup rules
- Template conventions for generated project files

### Task 9 — `.github/copilot-instructions.md` (full rewrite)
- PR requirements updated: 78 tests, 100% `src/` coverage, 0 audit vulnerabilities
- Testing rules consolidated
- Template task conventions documented

## Checklist

- [x] 78 tests still passing (no source/test changes)
- [x] CI now enforces `npm run test:coverage` in addition to `npm test`
- [x] Publish workflow gated on tests + coverage before `npm publish`
- [x] README reflects `create-gulp-khup` package identity (not gulpsheet)
- [x] AGENTS.md and copilot-instructions.md reflect actual Phase 2 codebase