### PR TITLE
chore: Phase 2 Task 10 — v1.0.0 release (version bump + CHANGELOG)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-# gulp-khup | Change Log
+# create-gulp-khup | Change Log
 
 All notable changes to this project will be documented in this file.
 
@@ -7,6 +7,39 @@ and this project adheres to
 [Semantic Versioning](http://semver.org/spec/v2.0.0.html)
 
 ## [Unreleased]
+
+## [1.0.0] - 2026-07-16
+
+### Added
+
+- `bin/create.js` — CLI entry point: `npm create gulp-khup@latest my-project`
+- `src/cli.js` — interactive prompt flow via `@clack/prompts` with input validation
+- `src/scaffold.js` — template file copying with `<%= token %>` substitution
+- `templates/base/` — Gulp 5 task suite: esbuild, Dart Sass, Biome, BrowserSync, ssh2-sftp-client
+- `templates/web/` — Static HTML project scaffold with full `src/` directory structure
+- Vitest test suite: 78 tests, 100% `src/` line/branch/function/statement coverage
+- GitHub Actions CI workflow with coverage enforcement
+- GitHub Actions npm publish workflow (triggered on GitHub Release)
+- `AGENTS.md` — AI agent guidance for the Phase 2 architecture
+- `.github/copilot-instructions.md` — coding conventions for the scaffolder
+
+### Changed
+
+- Package name: `gulp-khup` → `create-gulp-khup`
+- Package is now public (`private` removed)
+- Module system: Babel/CJS → native ESM (`"type": "module"`)
+- JS bundling in generated projects: Browserify + Babel → esbuild
+- CSS in generated projects: LibSass → Dart Sass
+- Linting/formatting in generated projects: ESLint + Prettier → Biome
+- Deploy in generated projects: `vinyl-ftp` + `gulp-sftp` → `ssh2-sftp-client`
+- Node.js minimum: 18 (generated projects also target Node 18+)
+- README rewritten for `npm create` usage
+
+### Removed
+
+- All legacy gulp-task dependencies from `package.json` (moved to `templates/base/package.json.tpl`)
+- `gulpfile.babel.js` top-level entry point (replaced by `bin/create.js`)
+- `.babelrc`, `.eslintrc`, `.browserslistrc`, `.prettierrc`, `.prettierignore` (legacy config)
 
 ## [0.1.1] - 2026-07-16
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.0.0-beta.1",
+  "version": "1.0.0",
   "type": "module",
   "bin": {
     "create-gulp-khup": "./bin/create.js"


### PR DESCRIPTION
## What This PR Does

Phase 2 Task 10 — final version bump and CHANGELOG for the `v1.0.0` release. This is the last PR into `next` before `next` → `develop` merge and the GitHub Release.

## Changes

### `package.json`
- `version`: `1.0.0-beta.1` → `1.0.0`

### `CHANGELOG.md`
- Header renamed: `gulp-khup` → `create-gulp-khup`
- `[1.0.0] - 2026-07-16` entry added with full `Added`, `Changed`, `Removed` sections
- `[Unreleased]` section cleared (ready for post-1.0.0 entries)
- `[0.1.1]` history preserved

## Smoke Test Results (verified locally before this commit)

```
scaffold() → /tmp/smoke-test-project
✓ 28 top-level files and directories generated
✓ package.json: name=smoke-test-project, author=Test Author, version=0.1.0
✓ CHANGELOG.md: year token substituted (2026)
✓ All 14 gulp task files present
✓ src/ directory with web template files
```

## Final Verification

```
npm test:        78 passed, 0 skipped
npm audit:       0 vulnerabilities
src/ coverage:   100% lines / branches / functions / statements
```

## After Merge

1. Open PR `next` → `develop`
2. Merge (squash)
3. Tag `v1.0.0` on `develop`
4. Create GitHub Release → triggers publish workflow → `npm publish`

## Checklist

- [x] Version bumped to `1.0.0` in `package.json`
- [x] CHANGELOG `[1.0.0]` entry complete
- [x] 78 tests passing
- [x] 0 audit vulnerabilities
- [x] 100% `src/` coverage
- [x] Smoke test verified scaffold output