### PR TITLE
chore: v1.1.0 release prep — version bump, CHANGELOG, TODO

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,32 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.0] - 2026-07-16
+
+### Added
+
+- **Email project type** — `templates/email/` — full nunjucks email template scaffold
+  with CSS inlining (`gulp-inline-css`), email-specific build/watch pipeline, 9 nunjucks
+  content block partials (headline, one-col, two-col, three-col-image, etc.)
+- **WordPress project type** — `templates/wordpress/` — WordPress theme development scaffold
+  with BrowserSync proxy mode (`WP_URL`), deploy to `wp-content/themes/<name>/`,
+  WP theme header in `theme.scss` (Theme Name, Author, Description, Version),
+  full SCSS base (variables, mixins, typography), components, and Gutenberg editor support
+
+### Changed
+
+- Email and WordPress options in CLI no longer show "coming soon" hint — both are fully functional
+
+### Removed
+
+- Legacy gulpsheet root files (`gulpfile.babel.js`, `gulp/`, `.babelrc`, `.browserslistrc`,
+  `.editorconfig`, `.eslintrc`, `.prettierignore`, `.prettierrc`) — removed as they were
+  orphaned v0.x artifacts with no relevance to the scaffolder
+
+### Fixed
+
+- `.nvmrc` updated from `16` → `18` to reflect the scaffolder's actual Node requirement
+
 ## [1.0.0] - 2026-07-16
 
 ### Added

--- a/TODO.md
+++ b/TODO.md
@@ -1,27 +1,11 @@
 # TODO
 
-`create-gulp-khup@1.0.0` is live on npm. This file tracks remaining post-1.0.0 work.
-
-Do not create a new GitHub Release until all items below are complete.
-
----
-
-## Active: Post-1.0.0 Polish
-
-### Remove legacy gulpsheet artifacts — [#53](https://github.com/uncleSoWise/gulp-khup/issues/53)
-Remove `gulpfile.babel.js`, `gulp/`, `.babelrc`, `.browserslistrc`, `.editorconfig`,
-`.eslintrc`, `.prettierignore`, `.prettierrc` from the repo root. Update `.nvmrc` to Node 18.
-
-### Email project template — [#52](https://github.com/uncleSoWise/gulp-khup/issues/52)
-Port the email template from the Archive (`generator-pnmg`) into `templates/email/`.
-Replaces the current stub README. Includes nunjucks email layouts + gulp tasks.
-
-### WordPress project template — [#51](https://github.com/uncleSoWise/gulp-khup/issues/51)
-Build a WordPress theme development scaffold (no Archive source — built fresh).
-CSS/JS/images only, deploy path targets `wp-content/themes/<slug>/`.
+All three project types are complete and `create-gulp-khup@1.1.0` is ready to release.
 
 ---
 
 ## Future (Phase 4+)
 
 - `cosmiconfig` support for customizing globs in generated projects (see [#18](https://github.com/uncleSoWise/gulp-khup/issues/18))
+- WordPress project type: advanced theme features (block patterns, block.json, theme.json)
+- Email project type: additional client-specific compatibility passes

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "type": "module",
   "bin": {
     "create-gulp-khup": "./bin/create.js"


### PR DESCRIPTION
## What This PR Does

Release prep for `v1.1.0` — version bump, CHANGELOG, and TODO update. After merge, tag `v1.1.0` and create a GitHub Release to trigger `npm publish`.

## Changes

### `package.json`
`1.0.0` → `1.1.0`

### `CHANGELOG.md`
New `[1.1.0] - 2026-07-16` entry:

**Added:**
- Email project type (nunjucks email templates, CSS inlining, 9 content block partials)
- WordPress project type (BrowserSync proxy, WP theme header, deploy to `wp-content/themes/`, Gutenberg editor support)

**Changed:**
- Email and WordPress CLI options no longer show "coming soon"

**Removed:**
- Legacy gulpsheet root files (`gulpfile.babel.js`, `gulp/`, config files)

**Fixed:**
- `.nvmrc` updated to Node 18

### `TODO.md`
All active items completed. Points to Phase 4+ future work.

## Final Verification

```
npm test:        95 passing, 0 skipped
npm audit:       0 vulnerabilities
src/ coverage:   100%
```

## After Merge

```bash
git tag -a v1.1.0 -m "Release v1.1.0"
git push origin v1.1.0
# Create GitHub Release → OIDC publish workflow fires
```

## Checklist

- [x] 95 tests passing
- [x] 0 audit vulnerabilities
- [x] CHANGELOG `[1.1.0]` entry complete
- [x] TODO updated
- [x] All three project types functional: Static HTML ✅ WordPress ✅ Email ✅