### PR TITLE
fix: restore NODE_AUTH_TOKEN in publish workflow + npm pkg fix corrections

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,7 +31,10 @@ jobs:
         run: npm run test:coverage
 
       - name: Publish to npm
-        # Uses GitHub OIDC token for authentication — no NPM_TOKEN needed.
-        # Requires: npm trusted publisher configured at npmjs.com for this repo.
-        # See: https://docs.npmjs.com/generating-provenance-statements
+        # NODE_AUTH_TOKEN is required — npm --provenance uses OIDC for signing
+        # only; the actual registry auth still requires a token.
+        # Requirement: npm account 2FA must be set to "Authorization only"
+        # (not "Authorization and write actions") so tokens can publish in CI.
         run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "1.1.0",
   "type": "module",
   "bin": {
-    "create-gulp-khup": "./bin/create.js"
+    "create-gulp-khup": "bin/create.js"
   },
   "exports": "./src/scaffold.js",
   "engines": {
@@ -21,7 +21,7 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/uncleSoWise/gulp-khup.git"
+    "url": "git+https://github.com/uncleSoWise/gulp-khup.git"
   },
   "license": "MIT",
   "scripts": {

--- a/test/package.test.js
+++ b/test/package.test.js
@@ -24,7 +24,7 @@ describe('package.json', () => {
   });
 
   it('declares the CLI bin entry point', () => {
-    expect(pkg.bin?.['create-gulp-khup']).toBe('./bin/create.js');
+    expect(pkg.bin?.['create-gulp-khup']).toBe('bin/create.js');
   });
 
   it('exports the scaffold module', () => {


### PR DESCRIPTION
## What This PR Does

Two fixes to unblock the v1.1.0 publish.

## Fix 1: Restore `NODE_AUTH_TOKEN` in `publish.yml`

**Root cause of the 404:** `--provenance` uses GitHub's OIDC token for *signing* (sigstore) but **not** for npm registry authentication. `actions/setup-node` with `registry-url` writes an `.npmrc` entry `_authToken=${NODE_AUTH_TOKEN}`. When `NODE_AUTH_TOKEN` is unset, this results in an empty auth token — npm uses that empty token instead of falling back to any OIDC exchange, producing an unauthenticated PUT → 404.

**Fix:** Restore `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}`.

**Remaining requirement:** The npm account 2FA mode must be set to **"Authorization only"** (npmjs.com → Account → 2FA settings). This allows tokens to publish in CI without an OTP. Currently set to "Authorization and write actions" which is why the original v1.0.0 workflow failed with `EOTP`.

## Fix 2: `npm pkg fix` corrections to `package.json`

npm auto-corrected these during the failed v1.1.0 publish attempt:

| Field | Before | After |
|-------|--------|-------|
| `bin["create-gulp-khup"]` | `"./bin/create.js"` | `"bin/create.js"` |
| `repository.url` | `"https://github.com/..."` | `"git+https://github.com/..."` |

**`test/package.test.js`** updated to match the normalized bin path.

## After Merge

1. On npmjs.com: change 2FA to **"Authorization only"**
2. Re-run the failed v1.1.0 workflow from the Actions tab — no new release needed

## Checklist

- [x] 95 tests passing
- [x] `package.json` normalized (no more `npm warn publish` warnings)
- [x] `NODE_AUTH_TOKEN` restored with explanatory comment