### PR TITLE
fix: remove registry-url from setup-node to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,10 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '20'
-          registry-url: 'https://registry.npmjs.org'
+          # No registry-url here — setup-node injects `_authToken=${NODE_AUTH_TOKEN}`
+          # into .npmrc when registry-url is set. With no token in use, that empty
+          # entry blocks npm from using OIDC trusted publishing. Omitting registry-url
+          # lets npm detect the OIDC environment and authenticate natively.
           cache: 'npm'
 
       - name: Install dependencies
@@ -31,10 +34,7 @@ jobs:
         run: npm run test:coverage
 
       - name: Publish to npm
-        # NODE_AUTH_TOKEN is required — npm --provenance uses OIDC for signing
-        # only; the actual registry auth still requires a token.
-        # Requirement: npm account 2FA must be set to "Authorization only"
-        # (not "Authorization and write actions") so tokens can publish in CI.
+        # No NODE_AUTH_TOKEN — uses npm trusted publishing via GitHub OIDC.
+        # Requires: package configured with a linked publisher on npmjs.com
+        # (package settings → Publishing → Linked publishers).
         run: npm publish --provenance --access public
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## What This PR Does

Removes `registry-url` from `setup-node` to fix OIDC trusted publishing (no token).

## Root Cause

When `registry-url` is set in `setup-node`, the action writes this to `.npmrc`:
```
//registry.npmjs.org/:_authToken=${NODE_AUTH_TOKEN}
```
With no `NODE_AUTH_TOKEN` in the environment, this expands to an empty string. npm reads that empty `_authToken` entry and attempts an **unauthenticated** PUT → 404. npm never reaches the OIDC path because `.npmrc` already has an (empty) auth entry.

## Fix

Remove `registry-url` from `setup-node`. Without it, no `_authToken` is written to `.npmrc`. npm then detects the GitHub Actions OIDC environment (`$ACTIONS_ID_TOKEN_REQUEST_URL`) and exchanges the GitHub OIDC JWT for a temporary publish token via the linked publisher on npmjs.com.

`cache: 'npm'` continues to work — it caches based on the `package-lock.json` hash, not the registry URL.

## After Merge

Re-run the failed v1.1.0 publish workflow from the Actions tab. No new release or tag needed.

> **If this still fails** with a different error, the next diagnostic step is to check the linked publisher configuration on npmjs.com — specifically that no branch/environment restriction is set that would prevent release-event OIDC tokens from matching.