### PR TITLE
fix: bump to v1.1.1 — hotfix to trigger fresh OIDC publish workflow run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,15 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.1] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: removed `registry-url` from `setup-node` to enable OIDC
+  trusted publishing — `registry-url` was injecting an empty `_authToken` into
+  `.npmrc` that blocked npm from detecting the OIDC environment
+- `package.json`: normalized `bin` path and `repository.url` format via `npm pkg fix`
+
 ## [1.1.0] - 2026-07-16
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
## What This PR Does

Hotfix bump to v1.1.1. No code changes — purely a version bump and CHANGELOG entry to trigger a **fresh** release workflow run that will pick up the publish fixes already on `develop`.

## Why a New Version Is Needed

Re-runs of GitHub Actions workflows use the workflow file **from when the run was originally created**, not the current HEAD. Both v1.1.0 publish attempts re-ran the old workflow (with `registry-url` still present), so the OIDC fix never got tested.

A new release tag triggers the workflow from `develop`, which now has:
- `registry-url` removed from `setup-node` (PR #59) — enables OIDC auth
- `package.json` normalized via `npm pkg fix` (PR #58) — no more publish warnings

## After Merge

```bash
git tag -a v1.1.1 -m "Release v1.1.1"
git push origin v1.1.1
# Create GitHub Release → fresh workflow run with updated publish.yml
```

## Checklist
- [x] 95 tests passing
- [x] Version bumped to 1.1.1
- [x] CHANGELOG updated