### PR TITLE
fix: restore registry-url, strip empty _authToken to enable OIDC trusted publishing

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,10 +18,7 @@ jobs:
       - uses: actions/setup-node@v7
         with:
           node-version: '20'
-          # No registry-url here — setup-node injects `_authToken=${NODE_AUTH_TOKEN}`
-          # into .npmrc when registry-url is set. With no token in use, that empty
-          # entry blocks npm from using OIDC trusted publishing. Omitting registry-url
-          # lets npm detect the OIDC environment and authenticate natively.
+          registry-url: 'https://registry.npmjs.org'
           cache: 'npm'
 
       - name: Install dependencies
@@ -33,8 +30,13 @@ jobs:
       - name: Verify 100% src/ coverage
         run: npm run test:coverage
 
+      - name: Enable OIDC trusted publishing
+        # setup-node writes `_authToken=${NODE_AUTH_TOKEN}` to .npmrc. When no
+        # token is provided that expands to empty string, which npm uses instead
+        # of falling back to OIDC. Removing that line lets npm detect the GitHub
+        # Actions OIDC environment and authenticate via the linked publisher.
+        run: |
+          sed -i '/^\/\/registry.npmjs.org\/:_authToken/d' "$NPM_CONFIG_USERCONFIG"
+
       - name: Publish to npm
-        # No NODE_AUTH_TOKEN — uses npm trusted publishing via GitHub OIDC.
-        # Requires: package configured with a linked publisher on npmjs.com
-        # (package settings → Publishing → Linked publishers).
         run: npm publish --provenance --access public


### PR DESCRIPTION
## What This PR Does

Surgical fix to enable npm OIDC trusted publishing. Keeps `registry-url` (npm needs the registry config) but immediately strips the empty `_authToken` line before publishing.

## The Two Failure Modes We Mapped

| Config | Result | Why |
|--------|--------|-----|
| `registry-url` + no token | `404 Not Found` | `setup-node` writes `_authToken=` (empty) to `.npmrc`; npm uses empty string instead of OIDC |
| No `registry-url` + no token | `ENEEDAUTH` | npm has no `.npmrc` at all; doesn't know to try OIDC |
| **This PR**: `registry-url` + strip `_authToken` | **Should work** | npm knows the registry, no token present → OIDC fallback |

## The Fix

```yaml
- uses: actions/setup-node@v7
  with:
    registry-url: 'https://registry.npmjs.org'  # ← configure registry
    cache: 'npm'

- name: Enable OIDC trusted publishing
  run: |
    # Remove the empty _authToken line setup-node injected
    sed -i '/^\/\/registry.npmjs.org\/:_authToken/d' "$NPM_CONFIG_USERCONFIG"

- name: Publish to npm
  run: npm publish --provenance --access public
```

`$NPM_CONFIG_USERCONFIG` is the `.npmrc` path set by `setup-node` — no hardcoded paths needed.

## After Merge

This will need another version bump (v1.1.2) to trigger a fresh workflow run since re-runs use the old workflow file.