### PR TITLE
fix: bump to v1.1.2 — trigger fresh OIDC publish workflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.2] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: restore `registry-url` in `setup-node` but strip the empty
+  `_authToken` line before publishing — enables npm OIDC trusted publishing by
+  ensuring npm has registry config but no token, allowing OIDC fallback
+
 ## [1.1.1] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.1",
+  "version": "1.1.2",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
Version bump to v1.1.2 to trigger a fresh publish workflow run using the updated `publish.yml` on `develop` (strip empty `_authToken` fix). No code changes.