### PR TITLE
debug: add .npmrc logging to diagnose OIDC trusted publishing failure

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -36,7 +36,14 @@ jobs:
         # of falling back to OIDC. Removing that line lets npm detect the GitHub
         # Actions OIDC environment and authenticate via the linked publisher.
         run: |
+          echo "=== .npmrc BEFORE strip ==="
+          cat "$NPM_CONFIG_USERCONFIG"
+          echo "=== stripping _authToken ==="
           sed -i '/^\/\/registry.npmjs.org\/:_authToken/d' "$NPM_CONFIG_USERCONFIG"
+          echo "=== .npmrc AFTER strip ==="
+          cat "$NPM_CONFIG_USERCONFIG"
+          echo "=== OIDC env vars ==="
+          echo "ACTIONS_ID_TOKEN_REQUEST_URL set: $([[ -n $ACTIONS_ID_TOKEN_REQUEST_URL ]] && echo YES || echo NO)"
 
       - name: Publish to npm
         run: npm publish --provenance --access public


### PR DESCRIPTION
## What This PR Does

Adds debug logging to the publish workflow to diagnose why npm OIDC trusted publishing is failing with `ENEEDAUTH`.

## What the Debug Output Will Tell Us

**`.npmrc` BEFORE strip:**
- If `_authToken` is empty string → `setup-node` is NOT exchanging the OIDC token → trusted publisher config on npmjs.com doesn't match our OIDC claims
- If `_authToken` has a value → `setup-node` IS exchanging the OIDC token → we should NOT be stripping it

**`.npmrc` AFTER strip:** confirms the line was removed

**`ACTIONS_ID_TOKEN_REQUEST_URL set: YES/NO`:** confirms OIDC env vars are available for npm to use

## Likely Root Cause

Based on the pattern of failures (404 with empty token, ENEEDAUTH without token), the trusted publisher configuration on npmjs.com likely has a **mismatch** — either the workflow path (`publish.yml` vs `.github/workflows/publish.yml`) or the package name (`gulp-khup` vs `create-gulp-khup`) or a branch restriction.

**Please check on npmjs.com → package `create-gulp-khup` → Settings → Trusted Publishers:**
- Repository: `uncleSoWise/gulp-khup` (exact owner/repo format)
- Workflow: `.github/workflows/publish.yml` (full path, not just `publish.yml`)
- No branch/environment restriction (or one that matches release events)

This PR + a v1.1.3 bump will give us the diagnostic output to confirm.