### PR TITLE
fix: bump to v1.1.3 — debug OIDC publish workflow run

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.3] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: debug run to diagnose OIDC trusted publishing failure
+
 ## [1.1.2] - 2026-07-16
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
Version bump to v1.1.3 to trigger the debug workflow run. The debug step will print `.npmrc` contents before/after the `_authToken` strip and confirm whether `ACTIONS_ID_TOKEN_REQUEST_URL` is available — this tells us exactly why OIDC trusted publishing is failing.