### PR TITLE
fix: bump to v1.1.4 — trigger OIDC JWT fetch publish workflow

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.3",
+  "version": "1.1.4",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
Version bump to v1.1.4 to trigger a fresh workflow run using the OIDC JWT fetch fix from PR #65.