### PR TITLE
chore: release v1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,23 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.5] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: upgrade npm to 11.5.1+ (`npm install -g npm@latest`) so the
+  runner has native OIDC trusted-publishing support. Node 20 ships npm 10.x,
+  which cannot perform the OIDC token exchange — the true root cause of the
+  earlier publish failures. Removed `registry-url`, `NODE_AUTH_TOKEN`, and the
+  manual JWT fetch; modern npm authenticates automatically via the linked
+  publisher on npmjs.com.
+
+## [1.1.4] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: attempted manual OIDC JWT fetch (superseded by 1.1.5)
+
 ## [1.1.3] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-gulp-khup",
-  "version": "1.0.0-beta.1",
+  "version": "1.1.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-gulp-khup",
-      "version": "1.0.0-beta.1",
+      "version": "1.1.5",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.4",
+  "version": "1.1.5",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
Release v1.1.5. Contains the definitive OIDC publish fix (npm upgraded to 11.5.1+ for native trusted-publishing support). Merge, then tag + release to trigger the publish workflow.