### PR TITLE
chore: release v1.1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,14 @@ and this project adheres to
 
 ## [Unreleased]
 
+## [1.1.6] - 2026-07-16
+
+### Fixed
+
+- Publish workflow: bump runner to Node 22. `npm@latest` is now v12 which
+  requires Node >=22; the Node 20 runner failed with `EBADENGINE`. Node 22
+  (current LTS) ships a modern npm with native OIDC trusted-publishing support.
+
 ## [1.1.5] - 2026-07-16
 
 ### Fixed

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "create-gulp-khup",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "create-gulp-khup",
-      "version": "1.1.5",
+      "version": "1.1.6",
       "license": "MIT",
       "dependencies": {
         "@clack/prompts": "^0.10.0"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.1.5",
+  "version": "1.1.6",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"


### PR DESCRIPTION
Release v1.1.6 — Node 22 runner fix for OIDC publishing. Merge, then tag + release.