### PR TITLE
fix: email compatibility — sync package.json, fix @media px unit, document CM merge tags (#77)

### DIFF
--- a/templates/email/package.json.tpl
+++ b/templates/email/package.json.tpl
@@ -21,18 +21,17 @@
   },
   "devDependencies": {
     "@biomejs/biome": "^2.2.4",
+    "autoprefixer": "^10.4.21",
     "beeper": "^3.0.0",
     "browser-sync": "^3.0.4",
     "chalk": "^5.6.2",
     "cssnano": "^7.1.1",
     "del": "^8.0.1",
     "dotenv": "^17.2.2",
-    "fancy-log": "^2.0.0",
     "gulp": "^5.0.1",
     "gulp-cached": "^1.1.1",
+    "gulp-changed": "^5.0.3",
     "gulp-flatmap": "^1.0.2",
-    "gulp-htmlmin": "^5.0.1",
-    "gulp-imagemin": "^9.1.0",
     "gulp-inline-css": "^4.0.0",
     "gulp-inline-source": "^4.0.0",
     "gulp-notify": "^5.0.0",
@@ -46,11 +45,20 @@
     "gulp-size": "^5.0.0",
     "gulp-sourcemaps": "^3.0.0",
     "gulp-special-html": "0.0.4",
+    "html-minifier-terser": "^7.2.0",
     "marked": "^16.3.0",
     "nunjucks": "^3.2.4",
     "nunjucks-markdown": "^2.0.1",
-    "postcss": "^8.5.6",
+    "postcss": "^8.5.10",
     "sass": "^1.93.2",
+    "sharp": "^0.34.0",
+    "svgo": "^3.3.2",
     "through2": "^4.0.2"
+  },
+  "overrides": {
+    "lodash.template": "^4.5.0",
+    "nth-check": "^2.1.1",
+    "terser": "^5.0.0",
+    "uuid": "^11.1.1"
   }
 }

--- a/templates/email/src/inc/_css.njk
+++ b/templates/email/src/inc/_css.njk
@@ -27,7 +27,18 @@
     ul,
     ol {Margin: 0 0 20px 0; padding: 0 0 0 20px;}
 
-    @media only screen and (max-width: 560) {
+    /*
+     * Responsive breakpoints
+     * Note: Gmail strips @media queries — this affects Gmail only.
+     * All other clients (Outlook, Apple Mail, iOS Mail, Samsung Mail) honour these rules.
+     * gulp-inline-css inlines the styles above; @media overrides must remain in <style>.
+     * Campaign Monitor merge tags used in this template:
+     *   <webversion>  — link to web version (below)
+     *   <currentyear> — current year in footer
+     *   <unsubscribe> — unsubscribe link in footer
+     *   <singleline label="..."> — editable single-line text region
+     */
+    @media only screen and (max-width: 560px) {
       .table {width: 320px !important; margin: 0 auto !important; overflow: hidden !important;}
       .footer span {text-align: center !important;}
       .mobile-hide {display: none !important;}

--- a/templates/email/src/inc/_footer.njk
+++ b/templates/email/src/inc/_footer.njk
@@ -7,6 +7,7 @@
           <tr>
             <td width="20" class="mobile-padding"></td>
             <td width="280" class="column" valign="top" align="left">
+              <!-- Campaign Monitor merge tags: <currentyear> outputs the current year, <unsubscribe> renders the unsubscribe link. -->
               <span class="copyright">&copy; <currentyear> Company Name. All rights reserved.</span><br /><br />
               <span class="address">
                 5017 Washington Pl<br/>

--- a/test/scaffold.test.js
+++ b/test/scaffold.test.js
@@ -294,6 +294,70 @@ describe('scaffold — email project type', () => {
 });
 
 // ---------------------------------------------------------------------------
+// Email compatibility (#77)
+// ---------------------------------------------------------------------------
+
+describe('scaffold — email compatibility (#77)', () => {
+  let tmpDir, outDir;
+  const emailDefaults = {
+    projectName: 'test-email',
+    description: 'A test email project',
+    authorName: 'Test Author',
+    authorEmail: 'test@example.com',
+    projectType: 'email',
+  };
+
+  beforeEach(async () => {
+    tmpDir = await mkdtemp(join(tmpdir(), 'gulp-khup-email77-'));
+    outDir = join(tmpDir, 'output');
+    await scaffold({ ...emailDefaults, outDir });
+  });
+
+  afterEach(async () => {
+    await rm(tmpDir, { recursive: true, force: true });
+  });
+
+  it('email package.json has html-minifier-terser, not gulp-htmlmin', async () => {
+    const { readFile } = await import('fs/promises');
+    const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf-8'));
+    expect(pkg.devDependencies).not.toHaveProperty('gulp-htmlmin');
+    expect(pkg.devDependencies).not.toHaveProperty('gulp-imagemin');
+    expect(pkg.devDependencies).not.toHaveProperty('fancy-log');
+    expect(pkg.devDependencies).toHaveProperty('html-minifier-terser');
+    expect(pkg.devDependencies).toHaveProperty('sharp');
+    expect(pkg.devDependencies).toHaveProperty('autoprefixer');
+  });
+
+  it('email package.json has npm overrides for security', async () => {
+    const { readFile } = await import('fs/promises');
+    const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf-8'));
+    expect(pkg.overrides).toBeDefined();
+    expect(pkg.overrides).toHaveProperty('nth-check');
+  });
+
+  it('_css.njk mobile breakpoint uses max-width: 560px with px unit', async () => {
+    const { readFile } = await import('fs/promises');
+    const content = await readFile(join(outDir, 'src', 'inc', '_css.njk'), 'utf-8');
+    expect(content).toContain('max-width: 560px');
+    expect(content).not.toContain('max-width: 560)');
+  });
+
+  it('_css.njk documents Campaign Monitor merge tags and Gmail behaviour', async () => {
+    const { readFile } = await import('fs/promises');
+    const content = await readFile(join(outDir, 'src', 'inc', '_css.njk'), 'utf-8');
+    expect(content).toContain('Campaign Monitor');
+    expect(content).toContain('Gmail');
+  });
+
+  it('_footer.njk documents currentyear as a Campaign Monitor merge tag', async () => {
+    const { readFile } = await import('fs/promises');
+    const content = await readFile(join(outDir, 'src', 'inc', '_footer.njk'), 'utf-8');
+    expect(content).toContain('Campaign Monitor');
+    expect(content).toContain('<currentyear>');
+  });
+});
+
+// ---------------------------------------------------------------------------
 // scaffold() — wordpress project type
 // ---------------------------------------------------------------------------
 


### PR DESCRIPTION
## Summary

Closes #77

Four targeted email fixes — the build was broken and key behaviours were undocumented.

---

## Changes

### `templates/email/package.json.tpl` — synced with base
- Removed `gulp-htmlmin`, `gulp-imagemin`, `fancy-log` (deprecated/removed in Phase 3)
- Added `html-minifier-terser ^7.2.0`, `sharp ^0.34.0`, `svgo ^3.3.2` (modern replacements)
- Added missing base deps: `autoprefixer`, `gulp-changed`, `gulp-flatmap`
- Added `npm overrides` for `lodash.template`, `nth-check`, `terser`, `uuid` (security)
- Bumped `postcss` to `^8.5.10`

The email `gulp build` was failing with `Cannot find package 'autoprefixer'` — this fixes it.

### `templates/email/src/inc/_css.njk`
- Fixed `@media only screen and (max-width: 560)` → `max-width: 560px` (missing `px` unit — query never fired)
- Added comment block explaining:
  - Campaign Monitor merge tags used in this template (`<webversion>`, `<currentyear>`, `<unsubscribe>`, `<singleline>`)
  - Gmail behaviour: strips `@media` queries — expected, `gulp-inline-css` handles the rest

### `templates/email/src/inc/_footer.njk`
- Added inline comment documenting `<currentyear>` and `<unsubscribe>` as Campaign Monitor merge tags

---

## What was NOT lost
Diff against the Archive confirmed: every difference between Archive and current templates was the Phase 2 EJS token replacement (hardcoded widths, colours). No structural email content was lost.

---

## Tests

5 new tests. **130/130 pass. `gulp build` succeeds on a fresh email scaffold.**