### PR TITLE
feat: add CLI flags (--yes, --type, --description, --version, --help) + npm-valid name validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.0] - 2026-07-18
+
 ### Added
 - `--yes`/`-y` flag: skip all prompts; uses `--type` (default `web`), `--description`, and git config for author/email fields
 - `--type` flag: pre-select project type (`web`, `wordpress`, `email`) — works in both interactive (pre-fills prompt) and `--yes` mode
@@ -252,7 +254,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ---
 
-[Unreleased]: https://github.com/uncleSoWise/gulp-khup/compare/v1.3.1...HEAD
+[Unreleased]: https://github.com/uncleSoWise/gulp-khup/compare/v1.4.0...HEAD
+[1.4.0]: https://github.com/uncleSoWise/gulp-khup/compare/v1.3.1...v1.4.0
 [1.3.1]: https://github.com/uncleSoWise/gulp-khup/compare/v1.3.0...v1.3.1
 [1.3.0]: https://github.com/uncleSoWise/gulp-khup/compare/v1.2.1...v1.3.0
 [1.2.1]: https://github.com/uncleSoWise/gulp-khup/compare/v1.2.0...v1.2.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- `--yes`/`-y` flag: skip all prompts; uses `--type` (default `web`), `--description`, and git config for author/email fields
+- `--type` flag: pre-select project type (`web`, `wordpress`, `email`) — works in both interactive (pre-fills prompt) and `--yes` mode
+- `--description` flag: pre-fill or set description
+- `--version`/`-v` flag: print version and exit
+- `--help`/`-h` flag: print usage summary and exit
+
+### Changed
+- `validateProjectName` now enforces npm package name rules: lowercase only, must start with a letter or number, max 214 characters
+- `promptUser` now accepts an `initialValues` object to pre-fill any prompt field (previously only project name was pre-fillable)
+
 ## [1.3.1] - 2026-07-17
 
 ### Fixed

--- a/bin/create.js
+++ b/bin/create.js
@@ -2,7 +2,7 @@
 import { parseArgs } from 'node:util';
 import { readFile } from 'node:fs/promises';
 import * as p from '@clack/prompts';
-import { promptUser, sanitizeProjectName, getGitConfig } from '../src/cli.js';
+import { promptUser, sanitizeProjectName, validateProjectName, getGitConfig } from '../src/cli.js';
 import { scaffold } from '../src/scaffold.js';
 
 let flags, positionals;
@@ -60,6 +60,11 @@ let values;
 if (flags.yes) {
   if (!rawArg) {
     p.log.error('Project name is required with --yes. Usage: npm create gulp-khup@latest <name> --yes');
+    process.exit(1);
+  }
+  const nameError = validateProjectName(initialName);
+  if (nameError) {
+    p.log.error(nameError);
     process.exit(1);
   }
   const [authorName, authorEmail] = await Promise.all([

--- a/bin/create.js
+++ b/bin/create.js
@@ -1,12 +1,86 @@
 #!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
 import * as p from '@clack/prompts';
-import { promptUser, sanitizeProjectName } from '../src/cli.js';
+import { promptUser, sanitizeProjectName, getGitConfig } from '../src/cli.js';
 import { scaffold } from '../src/scaffold.js';
 
-const rawArg = process.argv[2];
+let flags, positionals;
+try {
+  const parsed = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      version:     { type: 'boolean', short: 'v' },
+      help:        { type: 'boolean', short: 'h' },
+      type:        { type: 'string' },
+      description: { type: 'string' },
+      yes:         { type: 'boolean', short: 'y' },
+    },
+    allowPositionals: true,
+  });
+  flags = parsed.values;
+  positionals = parsed.positionals;
+} catch (err) {
+  p.log.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
+if (flags.version) {
+  const pkg = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+  console.log(pkg.version);
+  process.exit(0);
+}
+
+if (flags.help) {
+  console.log(`
+Usage: npm create gulp-khup@latest <project-name> [options]
+
+Options:
+  --type <type>          Project type: web, wordpress, or email (default: web)
+  --description <text>   Short project description
+  --yes, -y              Skip prompts and use defaults
+  --version, -v          Print version and exit
+  --help, -h             Show this help and exit
+`);
+  process.exit(0);
+}
+
+const VALID_TYPES = new Set(['web', 'wordpress', 'email']);
+if (flags.type && !VALID_TYPES.has(flags.type)) {
+  p.log.error(`Invalid --type "${flags.type}". Must be: web, wordpress, or email.`);
+  process.exit(1);
+}
+
+const rawArg = positionals[0];
 const initialName = rawArg ? sanitizeProjectName(rawArg) : '';
 
-const values = await promptUser({ projectName: initialName });
+let values;
+if (flags.yes) {
+  if (!rawArg) {
+    p.log.error('Project name is required with --yes. Usage: npm create gulp-khup@latest <name> --yes');
+    process.exit(1);
+  }
+  const [authorName, authorEmail] = await Promise.all([
+    getGitConfig('user.name'),
+    getGitConfig('user.email'),
+  ]);
+  values = {
+    projectName: initialName,
+    description: flags.description ?? '',
+    authorName,
+    authorEmail,
+    projectType: /** @type {import('../src/cli.js').ProjectType} */ (flags.type ?? 'web'),
+  };
+} else {
+  values = await promptUser({
+    projectName: initialName,
+    ...(flags.type        && { projectType:   /** @type {import('../src/cli.js').ProjectType} */ (flags.type) }),
+    ...(flags.description !== undefined && { description: flags.description }),
+  });
+}
+
 const projectName = sanitizeProjectName(values.projectName);
 
 p.log.step(`Scaffolding ${projectName}...`);

--- a/bin/create.js
+++ b/bin/create.js
@@ -6,7 +6,7 @@ import { scaffold } from '../src/scaffold.js';
 const rawArg = process.argv[2];
 const initialName = rawArg ? sanitizeProjectName(rawArg) : '';
 
-const values = await promptUser(initialName);
+const values = await promptUser({ projectName: initialName });
 const projectName = sanitizeProjectName(values.projectName);
 
 p.log.step(`Scaffolding ${projectName}...`);

--- a/bin/create.js
+++ b/bin/create.js
@@ -35,7 +35,7 @@ if (flags.version) {
 
 if (flags.help) {
   console.log(`
-Usage: npm create gulp-khup@latest <project-name> [options]
+Usage: npm create gulp-khup@latest [project-name] [options]
 
 Options:
   --type <type>          Project type: web, wordpress, or email (default: web)

--- a/docs/superpowers/plans/2026-07-18-repo-dx.md
+++ b/docs/superpowers/plans/2026-07-18-repo-dx.md
@@ -1,0 +1,380 @@
+# Repo DX Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add Biome linting to the scaffolder's own source, reduce CI test runtime by eliminating the redundant test-then-coverage double-run, and remove `--legacy-peer-deps` flags where the underlying conflicts have been resolved.
+
+**Architecture:** Three independent changes in a single chore PR. (1) Biome is added as a dev dep with a `biome.json` config and a `lint` script; a lint step is added to the existing `typecheck` CI job (zero extra setup time). (2) The `test` job's redundant `npm test` step is dropped — `npm run test:coverage` already runs the full suite with coverage. (3) `--legacy-peer-deps` flags are audited and removed if the peer conflicts are gone.
+
+**Tech Stack:** `@biomejs/biome`, GitHub Actions CI YAML.
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `package.json` | Add `@biomejs/biome` to `devDependencies`; add `lint` + `format` scripts |
+| Create | `biome.json` | Scaffolder Biome config (conservative, matches template `biome.json`) |
+| Modify | `.github/workflows/ci.yml` | Add lint step to `typecheck` job; remove redundant `npm test` step; remove `--legacy-peer-deps` where applicable |
+
+---
+
+## Task 1: Add Biome to the scaffolder
+
+**Files:**
+- Modify: `package.json`
+- Create: `biome.json`
+
+- [ ] **Step 1: Install `@biomejs/biome` as a dev dep**
+
+```bash
+npm install --save-dev @biomejs/biome
+```
+
+Expected: `package.json` `devDependencies` updated with `"@biomejs/biome": "^2.x.x"` (use the same major version as in `templates/base/biome.json`).
+
+- [ ] **Step 2: Check the version installed**
+
+```bash
+npx biome --version
+```
+
+Note the version for consistency with the template config.
+
+- [ ] **Step 3: Add scripts to `package.json`**
+
+```json
+"scripts": {
+  "test": "vitest run",
+  "test:coverage": "vitest run --coverage",
+  "test:watch": "vitest",
+  "lint": "biome check .",
+  "format": "biome format --write ."
+},
+```
+
+- [ ] **Step 4: Create `biome.json` at the repo root**
+
+```json
+{
+  "$schema": "https://biomejs.dev/schemas/2.0.0/schema.json",
+  "vcs": {
+    "enabled": true,
+    "clientKind": "git",
+    "useIgnoreFile": true
+  },
+  "files": {
+    "ignore": [
+      "templates/**",
+      "coverage/**",
+      "node_modules/**"
+    ]
+  },
+  "formatter": {
+    "enabled": true,
+    "indentStyle": "space",
+    "indentWidth": 2,
+    "lineWidth": 100
+  },
+  "linter": {
+    "enabled": true,
+    "rules": {
+      "recommended": true
+    }
+  },
+  "javascript": {
+    "formatter": {
+      "quoteStyle": "single",
+      "semicolons": "always"
+    }
+  }
+}
+```
+
+Use the same `$schema` version as `templates/base/biome.json`. Check that file first:
+
+```bash
+head -3 templates/base/biome.json
+```
+
+Update the `$schema` URL to match.
+
+**Important:** `templates/**` must be in `files.ignore` — the scaffolder's Biome config must not lint template files (those belong to the generated projects, not the scaffolder).
+
+- [ ] **Step 5: Run the linter and fix any issues**
+
+```bash
+npm run lint
+```
+
+If Biome reports issues in `src/`, `bin/`, or `test/`, fix them. Common issues:
+- `no-console` — the `bin/` files intentionally use `console.log`; add a `// biome-ignore lint/suspicious/noConsole: intentional CLI output` comment or configure the rule
+- Unused variables — fix them
+- Import ordering — `npm run format` will auto-fix most of these
+
+Run `npm run format` then `npm run lint` to get to zero issues.
+
+- [ ] **Step 6: Run tests to confirm nothing broke**
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0, 100% coverage on `src/`.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add package.json package-lock.json biome.json
+git commit -m "chore: add Biome linter to scaffolder devDeps with root biome.json config"
+```
+
+---
+
+## Task 2: Add lint step to CI `typecheck` job
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+- [ ] **Step 1: Add a lint step to the `typecheck` job**
+
+In `.github/workflows/ci.yml`, find the `typecheck` job. It currently ends with the `tsc` step. Add a lint step after it:
+
+```yaml
+      - name: Lint (Biome)
+        run: npm run lint
+```
+
+The full `typecheck` job after the change:
+
+```yaml
+  typecheck:
+    name: Type Check
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Type check (JSDoc via tsc)
+        run: npx tsc --project jsconfig.json --noEmit
+
+      - name: Lint (Biome)
+        run: npm run lint
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0. CI change is local only until pushed.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: add Biome lint step to typecheck job"
+```
+
+---
+
+## Task 3: Remove redundant `npm test` step from CI
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+The `test` job currently runs `npm test` (all tests, no coverage) and then `npm run test:coverage` (all tests again, with coverage). The second step is a strict superset. The first step is redundant.
+
+- [ ] **Step 1: Verify the current structure**
+
+```bash
+grep -n "npm test\|npm run test" .github/workflows/ci.yml
+```
+
+Expected output shows two lines in the `test` job: one for `npm test` and one for `npm run test:coverage`.
+
+- [ ] **Step 2: Remove the `npm test` step from the `test` job**
+
+In `.github/workflows/ci.yml`, delete these lines from the `test` job:
+
+```yaml
+      - name: Run tests
+        run: npm test
+
+```
+
+Keep only:
+
+```yaml
+      - name: Run tests with coverage (src/ must be 100%)
+        run: npm run test:coverage
+```
+
+The full `test` job after the change:
+
+```yaml
+  test:
+    name: Test (Node ${{ matrix.node-version }})
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: ['18', '22']
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: actions/setup-node@v7
+        with:
+          node-version: ${{ matrix.node-version }}
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci --ignore-scripts --legacy-peer-deps
+
+      - name: Run tests with coverage (src/ must be 100%)
+        run: npm run test:coverage
+```
+
+- [ ] **Step 3: Verify locally**
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0. All tests run exactly once.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add .github/workflows/ci.yml
+git commit -m "ci: drop redundant npm test step — npm run test:coverage runs the full suite"
+```
+
+---
+
+## Task 4: Investigate and remove `--legacy-peer-deps`
+
+**Files:**
+- Modify: `.github/workflows/ci.yml`
+
+The `--legacy-peer-deps` flag appears on every `npm ci` and `npm install` in CI. This suppresses peer dependency conflict errors rather than resolving them. If the underlying conflicts are gone (which they may be after the template dep cleanup in the template-quality PR), the flag should be removed.
+
+- [ ] **Step 1: Test scaffolder install without the flag**
+
+```bash
+npm ci --ignore-scripts
+```
+
+If this exits 0 with no peer dep errors: the conflict is resolved. Skip to Step 3.
+
+If it fails with a peer dep error: note the conflicting packages (e.g., `typescript@7.x` vs. a vitest peer that expects `typescript@5.x`). See Step 2.
+
+- [ ] **Step 2: Resolve the conflict (if present)**
+
+If `typescript ^7.0.2` conflicts with vitest's peer expectations, check what vitest actually requires:
+
+```bash
+npm info vitest@3 peerDependencies
+```
+
+If vitest accepts `typescript >= 5`, the conflict is a false positive from npm's stricter resolver. In that case, add a `"peerDependenciesMeta"` or use `"overrides"` in the scaffolder's own `package.json` to satisfy the resolution without `--legacy-peer-deps`. Example:
+
+```json
+"overrides": {
+  "typescript": "^7.0.2"
+}
+```
+
+Re-run `npm ci --ignore-scripts` to verify it exits 0.
+
+- [ ] **Step 3: Remove `--legacy-peer-deps` from CI scaffolder installs**
+
+In `.github/workflows/ci.yml`, for all jobs that install the scaffolder's own deps (not generated project installs), change:
+
+```yaml
+        run: npm ci --ignore-scripts --legacy-peer-deps
+# To:
+        run: npm ci --ignore-scripts
+```
+
+This applies to the `audit`, `typecheck`, `test`, and `integration` jobs' scaffolder install step.
+
+**Do not** remove the flag from the generated project install step (`npm install --legacy-peer-deps` in the integration job) unless the template-quality PR has already resolved the generated project peer conflicts.
+
+- [ ] **Step 4: Run full test suite to verify**
+
+```bash
+npm ci --ignore-scripts
+npm run test:coverage
+```
+
+Expected: both exit 0.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add .github/workflows/ci.yml package.json  # if overrides added
+git commit -m "ci: remove --legacy-peer-deps from scaffolder npm ci — peer conflicts resolved"
+```
+
+---
+
+## Task 5: Final verification and PR
+
+- [ ] **Step 1: Run full suite**
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0, 100% coverage.
+
+- [ ] **Step 2: Run type check**
+
+```bash
+npx tsc --project jsconfig.json --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 3: Run lint**
+
+```bash
+npm run lint
+```
+
+Expected: exits 0 (zero issues).
+
+- [ ] **Step 4: Update CHANGELOG**
+
+In `CHANGELOG.md`, add to `## [Unreleased]`:
+
+```markdown
+### Added
+- Biome linter configured for scaffolder source (`src/`, `bin/`, `test/`) — `npm run lint`
+
+### Changed
+- CI `test` job: removed redundant `npm test` step; only `npm run test:coverage` runs (halves test time per matrix leg)
+- CI `typecheck` job: added Biome lint step
+
+### Fixed
+- Removed `--legacy-peer-deps` from CI scaffolder installs (peer conflicts resolved)
+```
+
+- [ ] **Step 5: Open PR**
+
+```bash
+git push -u origin chore/repo-dx
+```
+
+Open PR targeting `main`. Title: `chore: add Biome to scaffolder, drop redundant CI test step, remove --legacy-peer-deps`.
+
+Note: this is a `chore` PR — no version bump needed.

--- a/docs/superpowers/plans/2026-07-18-scaffolder-core.md
+++ b/docs/superpowers/plans/2026-07-18-scaffolder-core.md
@@ -1,0 +1,534 @@
+# Scaffolder Core Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Add flag-based CLI mode (`--yes`, `--type`, `--description`, `--version`, `--help`), enforce npm-valid project names, and update `promptUser` to accept per-field pre-fills.
+
+**Architecture:** All flag parsing lives in `bin/create.js` using `util.parseArgs` (Node 18+ built-in). `src/cli.js` is updated in isolation — `validateProjectName` gets stricter rules, `promptUser` gets an `initialValues` object parameter. The two files stay independently unit-testable. `--yes` mode bypasses `promptUser` entirely and builds `ScaffoldValues` directly from flags + git config.
+
+**Tech Stack:** Node.js built-in `node:util` (`parseArgs`), `node:fs/promises` (`readFile` for version), `@clack/prompts` (existing).
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Modify | `src/cli.js` | `validateProjectName` stricter rules; `promptUser` signature → `initialValues` object |
+| Modify | `bin/create.js` | `parseArgs` flags, `--version`, `--help`, `--yes`, `--type`, `--description` |
+| Modify | `test/cli.test.js` | Update uppercase test; add npm-valid name tests |
+| Modify | `test/cli-prompt.test.js` | Update all `promptUser('')` calls; add `initialValues` pre-fill tests |
+| Modify | `test/bin.test.js` | Add structural checks for new imports and flags |
+
+---
+
+## Task 1: Enforce npm-valid project names
+
+**Files:**
+- Modify: `test/cli.test.js`
+- Modify: `src/cli.js`
+
+- [ ] **Step 1: Add failing tests**
+
+In `test/cli.test.js`, inside `describe('validateProjectName', ...)`, replace the existing uppercase test and add new cases:
+
+```js
+// Replace this test (line ~65):
+//   it('returns undefined for an uppercase name (no case restriction in validation)', ...)
+// With:
+it('rejects an uppercase name', () => {
+  expect(validateProjectName('MyProject')).toMatch(/lowercase/i);
+});
+
+// Add after the existing tests:
+it('rejects a name starting with a hyphen', () => {
+  expect(validateProjectName('-myproject')).toMatch(/invalid/i);
+});
+
+it('rejects a name starting with an underscore', () => {
+  expect(validateProjectName('_myproject')).toMatch(/invalid/i);
+});
+
+it('rejects a name longer than 214 characters', () => {
+  expect(validateProjectName('a'.repeat(215))).toMatch(/214/);
+});
+
+it('accepts a name exactly 214 characters long', () => {
+  expect(validateProjectName('a'.repeat(214))).toBeUndefined();
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'FAIL|PASS|rejects|accepts.*214'
+```
+
+Expected: the new tests fail (`MyProject` currently returns `undefined`; `-myproject` and `_myproject` also currently return `undefined`).
+
+- [ ] **Step 3: Update `validateProjectName` in `src/cli.js`**
+
+Replace the current character-class check:
+
+```js
+// Before (in validateProjectName):
+  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
+    return 'Invalid project name: use only letters, numbers, hyphens, and underscores';
+  }
+  return undefined;
+
+// After:
+  if (trimmed.length > 214) {
+    return 'Invalid project name: must be 214 characters or fewer';
+  }
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(trimmed)) {
+    return 'Invalid project name: use only lowercase letters, numbers, hyphens, and underscores; must start with a letter or number';
+  }
+  return undefined;
+```
+
+The new regex `^[a-z0-9][a-z0-9_-]*$` enforces: starts with lowercase letter or digit, followed by any combination of lowercase letters, digits, underscores, and hyphens. Leading `-` and `_` both fail. Uppercase fails.
+
+- [ ] **Step 4: Run tests — verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass. `sanitizeProjectName` tests are unaffected (the space→hyphen behaviour stays — it's still used on CLI positional args before validation runs).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add src/cli.js test/cli.test.js
+git commit -m "feat: enforce npm-valid project names in validateProjectName"
+```
+
+---
+
+## Task 2: Update `promptUser` to accept `initialValues` object
+
+**Files:**
+- Modify: `src/cli.js`
+- Modify: `bin/create.js`
+- Modify: `test/cli-prompt.test.js`
+
+- [ ] **Step 1: Add failing tests for `initialValues` pre-fill**
+
+In `test/cli-prompt.test.js`, add inside `describe('promptUser', ...)`:
+
+```js
+it('accepts an initialValues object (no error thrown with object arg)', async () => {
+  p.group.mockResolvedValueOnce(mockValues);
+  await expect(promptUser({ projectName: 'init-name' })).resolves.toBeDefined();
+});
+
+it('passes initialValues.projectName as initialValue to the projectName prompt', async () => {
+  p.group.mockImplementationOnce(async (fieldsObj) => {
+    await fieldsObj.projectName();
+    return mockValues;
+  });
+  await promptUser({ projectName: 'pre-filled' });
+  expect(p.text).toHaveBeenCalledWith(
+    expect.objectContaining({ initialValue: 'pre-filled' })
+  );
+});
+
+it('passes initialValues.description as initialValue to the description prompt', async () => {
+  p.group.mockImplementationOnce(async (fieldsObj) => {
+    await fieldsObj.description();
+    return mockValues;
+  });
+  await promptUser({ description: 'pre-filled desc' });
+  expect(p.text).toHaveBeenCalledWith(
+    expect.objectContaining({ initialValue: 'pre-filled desc' })
+  );
+});
+```
+
+- [ ] **Step 2: Update all existing `promptUser('')` calls in the test file**
+
+Replace every `promptUser('')` and `promptUser('pre-filled-name')` call:
+
+```js
+// Before:
+await promptUser('');
+// After:
+await promptUser({});
+
+// Before:
+await promptUser('pre-filled-name');
+// After:
+await promptUser({ projectName: 'pre-filled-name' });
+```
+
+- [ ] **Step 3: Run tests — verify new tests fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'FAIL|initialValues|pre-filled'
+```
+
+Expected: the new `initialValues` tests fail (signature mismatch).
+
+- [ ] **Step 4: Update `promptUser` signature in `src/cli.js`**
+
+Replace the function signature and destructure `initialValues`:
+
+```js
+// Before:
+export async function promptUser(initialName = '') {
+  const p = await import('@clack/prompts');
+
+  p.intro('create-gulp-khup');
+
+  const [authorName, authorEmail] = await Promise.all([
+    getGitConfig('user.name'),
+    getGitConfig('user.email'),
+  ]);
+
+  const values = await p.group(
+    {
+      projectName: () =>
+        p.text({
+          message: 'What is your project name?',
+          initialValue: initialName,
+          validate: validateProjectName,
+        }),
+      description: () =>
+        p.text({
+          message: 'Short description?',
+          placeholder: 'A static marketing site',
+        }),
+      authorName: () =>
+        p.text({
+          message: 'Author name?',
+          initialValue: authorName,
+        }),
+      authorEmail: () =>
+        p.text({
+          message: 'Author email?',
+          initialValue: authorEmail,
+        }),
+
+// After:
+/**
+ * @param {{ projectName?: string, description?: string, projectType?: ProjectType, authorName?: string, authorEmail?: string }} [initialValues={}]
+ */
+export async function promptUser(initialValues = {}) {
+  const {
+    projectName: initialName = '',
+    description: initialDescription = '',
+    projectType: initialProjectType,
+    authorName: prefilledAuthorName,
+    authorEmail: prefilledAuthorEmail,
+  } = initialValues;
+
+  const p = await import('@clack/prompts');
+
+  p.intro('create-gulp-khup');
+
+  const [gitAuthorName, gitAuthorEmail] = await Promise.all([
+    getGitConfig('user.name'),
+    getGitConfig('user.email'),
+  ]);
+
+  const values = await p.group(
+    {
+      projectName: () =>
+        p.text({
+          message: 'What is your project name?',
+          initialValue: initialName,
+          validate: validateProjectName,
+        }),
+      description: () =>
+        p.text({
+          message: 'Short description?',
+          placeholder: 'A static marketing site',
+          initialValue: initialDescription,
+        }),
+      authorName: () =>
+        p.text({
+          message: 'Author name?',
+          initialValue: prefilledAuthorName ?? gitAuthorName,
+        }),
+      authorEmail: () =>
+        p.text({
+          message: 'Author email?',
+          initialValue: prefilledAuthorEmail ?? gitAuthorEmail,
+        }),
+```
+
+Also update the `projectType` select to use `initialProjectType`:
+
+```js
+      projectType: () =>
+        p.select({
+          message: 'Project type?',
+          initialValue: initialProjectType,
+          options: [
+            { value: 'web', label: 'Static HTML', hint: 'recommended' },
+            { value: 'wordpress', label: 'WordPress' },
+            { value: 'email', label: 'Email' },
+          ],
+        }),
+```
+
+- [ ] **Step 5: Update `bin/create.js` call site**
+
+```js
+// Before:
+const values = await promptUser(initialName);
+
+// After:
+const values = await promptUser({ projectName: initialName });
+```
+
+- [ ] **Step 6: Run tests — verify they pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add src/cli.js bin/create.js test/cli-prompt.test.js
+git commit -m "feat: update promptUser to accept initialValues object for per-field pre-fill"
+```
+
+---
+
+## Task 3: Add flag parsing, `--version`, and `--help`
+
+**Files:**
+- Modify: `test/bin.test.js`
+- Modify: `bin/create.js`
+
+- [ ] **Step 1: Add failing structural tests**
+
+In `test/bin.test.js`, add:
+
+```js
+it('imports parseArgs from node:util', () => {
+  expect(source).toContain("from 'node:util'");
+  expect(source).toContain('parseArgs');
+});
+
+it('handles the --version flag', () => {
+  expect(source).toContain('flags.version');
+  expect(source).toContain('pkg.version');
+});
+
+it('handles the --help flag', () => {
+  expect(source).toContain('flags.help');
+  expect(source).toContain('--type');
+  expect(source).toContain('--yes');
+  expect(source).toContain('--version');
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'FAIL|parseArgs|version|help'
+```
+
+- [ ] **Step 3: Rewrite `bin/create.js` with flag parsing**
+
+```js
+#!/usr/bin/env node
+import { parseArgs } from 'node:util';
+import { readFile } from 'node:fs/promises';
+import * as p from '@clack/prompts';
+import { promptUser, sanitizeProjectName, getGitConfig } from '../src/cli.js';
+import { scaffold } from '../src/scaffold.js';
+
+let flags, positionals;
+try {
+  const parsed = parseArgs({
+    args: process.argv.slice(2),
+    options: {
+      version:     { type: 'boolean', short: 'v' },
+      help:        { type: 'boolean', short: 'h' },
+      type:        { type: 'string' },
+      description: { type: 'string' },
+      yes:         { type: 'boolean', short: 'y' },
+    },
+    allowPositionals: true,
+  });
+  flags = parsed.values;
+  positionals = parsed.positionals;
+} catch (err) {
+  p.log.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+
+if (flags.version) {
+  const pkg = JSON.parse(
+    await readFile(new URL('../package.json', import.meta.url), 'utf-8')
+  );
+  console.log(pkg.version);
+  process.exit(0);
+}
+
+if (flags.help) {
+  console.log(`
+Usage: npm create gulp-khup@latest <project-name> [options]
+
+Options:
+  --type <type>          Project type: web, wordpress, or email (default: web)
+  --description <text>   Short project description
+  --yes, -y              Skip prompts and use defaults
+  --version, -v          Print version and exit
+  --help, -h             Show this help and exit
+`);
+  process.exit(0);
+}
+
+const VALID_TYPES = new Set(['web', 'wordpress', 'email']);
+if (flags.type && !VALID_TYPES.has(flags.type)) {
+  p.log.error(`Invalid --type "${flags.type}". Must be: web, wordpress, or email.`);
+  process.exit(1);
+}
+
+const rawArg = positionals[0];
+const initialName = rawArg ? sanitizeProjectName(rawArg) : '';
+
+let values;
+if (flags.yes) {
+  if (!rawArg) {
+    p.log.error('Project name is required with --yes. Usage: npm create gulp-khup@latest <name> --yes');
+    process.exit(1);
+  }
+  const [authorName, authorEmail] = await Promise.all([
+    getGitConfig('user.name'),
+    getGitConfig('user.email'),
+  ]);
+  values = {
+    projectName: initialName,
+    description: flags.description ?? '',
+    authorName,
+    authorEmail,
+    projectType: /** @type {import('../src/cli.js').ProjectType} */ (flags.type ?? 'web'),
+  };
+} else {
+  values = await promptUser({
+    projectName: initialName,
+    ...(flags.type       && { projectType:  /** @type {import('../src/cli.js').ProjectType} */ (flags.type) }),
+    ...(flags.description !== undefined && { description: flags.description }),
+  });
+}
+
+const projectName = sanitizeProjectName(values.projectName);
+
+p.log.step(`Scaffolding ${projectName}...`);
+
+try {
+  await scaffold({ ...values, projectName });
+  p.outro(`Done! Run:\n\n  cd ${projectName}\n  npm install\n  gulp`);
+} catch (err) {
+  p.log.error(err instanceof Error ? err.message : String(err));
+  process.exit(1);
+}
+```
+
+- [ ] **Step 4: Add structural tests for `--yes` and `--type`**
+
+In `test/bin.test.js`, add:
+
+```js
+it('handles the --yes flag for non-interactive mode', () => {
+  expect(source).toContain('flags.yes');
+  expect(source).toContain('getGitConfig');
+});
+
+it('validates --type against VALID_TYPES', () => {
+  expect(source).toContain('VALID_TYPES');
+});
+
+it('imports getGitConfig from src/cli.js', () => {
+  expect(source).toContain('getGitConfig');
+});
+```
+
+- [ ] **Step 5: Run tests — verify all pass**
+
+```bash
+npm test
+```
+
+Expected: all tests pass. Coverage must stay at 100% for `src/`.
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add bin/create.js test/bin.test.js
+git commit -m "feat: add --version, --help, --type, --description, --yes flags to CLI"
+```
+
+---
+
+## Task 4: Verify type checking and open PR
+
+- [ ] **Step 1: Run TypeScript type check**
+
+```bash
+npx tsc --project jsconfig.json --noEmit
+```
+
+Expected: exits 0 (no type errors). If errors appear, fix the JSDoc annotations in `bin/create.js` (e.g., `@type {ProjectType}` casts).
+
+- [ ] **Step 2: Manual smoke test**
+
+```bash
+node bin/create.js --version
+# Expected: 1.3.1
+
+node bin/create.js --help
+# Expected: prints usage with --type, --yes, --version, --help
+
+node bin/create.js smoke-test --yes --type=web
+# Expected: creates smoke-test/ directory without prompts
+
+rm -rf smoke-test
+```
+
+- [ ] **Step 3: Run full test suite one final time**
+
+```bash
+npm run test:coverage
+```
+
+Expected: 100% coverage on `src/`, all tests pass.
+
+- [ ] **Step 4: Open PR**
+
+```bash
+git push -u origin feat/<issue>-scaffolder-core
+```
+
+Open PR targeting `main`. Title: `feat: add CLI flags (--yes, --type, --description, --version, --help)`.
+
+Bump version to `1.4.0` in `package.json` and update `CHANGELOG.md` `[Unreleased]` section:
+
+```markdown
+## [Unreleased]
+
+### Added
+- `--yes`/`-y` flag: skip all prompts; uses `--type` (default `web`), `--description`, and git config for author fields
+- `--type` flag: pre-select project type (`web`, `wordpress`, `email`) without prompting
+- `--description` flag: pre-fill description prompt
+- `--version`/`-v` flag: print version and exit
+- `--help`/`-h` flag: print usage summary and exit
+
+### Changed
+- `validateProjectName` now enforces npm package name rules: lowercase only, must start with a letter or number, max 214 characters
+```

--- a/docs/superpowers/plans/2026-07-18-template-quality.md
+++ b/docs/superpowers/plans/2026-07-18-template-quality.md
@@ -1,0 +1,879 @@
+# Template Quality Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Remove four unmaintained/deprecated dependencies from generated project templates, fix two code quality bugs, split `scaffold.test.js` into per-type files, and create type-specific `package.json.tpl` files so each project type gets only the deps it needs.
+
+**Architecture:** Three layers of changes. (1) Task file changes: replace `through2`, `gulp-touch-cmd`, `gulp-special-html` with native Node.js or inline equivalents — no behaviour change, just removing pinned/unmaintained packages. (2) Manifest changes: `web/package.json.tpl` and `wordpress/package.json.tpl` are created as complete, self-contained files that override `base/package.json.tpl` during the scaffold merge. (3) Test changes: `scaffold.test.js` is split into three focused files sharing a common lifecycle helper. All snapshot tests are updated at the end via `vitest run -u`.
+
+**Tech Stack:** Node.js built-in `node:stream` (`Transform`), `node:fs/promises` (`utimes`), Vitest snapshots.
+
+---
+
+## File Map
+
+| Action | File | Change |
+|--------|------|--------|
+| Create | `test/helpers.js` | Shared `mkdtemp`/`rm` lifecycle |
+| Create | `test/scaffold-web.test.js` | Web-type scaffold tests (from scaffold.test.js) |
+| Create | `test/scaffold-wordpress.test.js` | WordPress-type scaffold tests (from scaffold.test.js) |
+| Create | `test/scaffold-email.test.js` | Email-type scaffold tests (from scaffold.test.js) |
+| Modify | `test/scaffold.test.js` | Keep only: `applyTokens`, `resolveTemplateDirs`, directory-handling tests |
+| Modify | `templates/base/gulp/tasks/css.js` | Replace `through2`, fix `// bytes` comment |
+| Modify | `templates/base/gulp/tasks/js.js` | Replace `through2`, replace `gulp-touch-cmd` |
+| Modify | `templates/base/gulp/tasks/img.js` | Replace `through2` |
+| Modify | `templates/base/gulp/tasks/html.js` | Replace `through2`, replace `gulp-special-html` |
+| Modify | `templates/base/package.json.tpl` | Remove type-specific + deprecated deps; remove `repository` field |
+| Create | `templates/web/package.json.tpl` | Complete web manifest (base deps + web-only deps) |
+| Create | `templates/wordpress/package.json.tpl` | Complete WordPress manifest (base deps + wp-only deps) |
+| Modify | `templates/email/package.json.tpl` | Remove `repository` field; remove `gulp-inline-source` if unused |
+| Update | `test/__snapshots__/*.snap` | Regenerate after all manifest changes |
+
+---
+
+## Task 1: Split `scaffold.test.js` — extract shared helper and per-type files
+
+**Files:**
+- Create: `test/helpers.js`
+- Create: `test/scaffold-web.test.js`
+- Create: `test/scaffold-wordpress.test.js`
+- Create: `test/scaffold-email.test.js`
+- Modify: `test/scaffold.test.js`
+
+This task is a pure refactor — no behaviour change, same test count.
+
+- [ ] **Step 1: Create `test/helpers.js`**
+
+```js
+import { mkdtemp, rm } from 'fs/promises';
+import { join } from 'path';
+import { tmpdir } from 'os';
+
+/**
+ * Create a temp dir, return path + cleanup function.
+ * @param {string} [prefix='gulp-khup-test-']
+ * @returns {Promise<{ tmpDir: string, cleanup: () => Promise<void> }>}
+ */
+export async function makeTmpDir(prefix = 'gulp-khup-test-') {
+  const tmpDir = await mkdtemp(join(tmpdir(), prefix));
+  return {
+    tmpDir,
+    cleanup: () => rm(tmpDir, { recursive: true, force: true }),
+  };
+}
+```
+
+- [ ] **Step 2: Move web-type tests to `test/scaffold-web.test.js`**
+
+Extract the `describe('scaffold — web project: file content', ...)` block and any web-specific snapshot tests from `scaffold.test.js` into a new file. Use `makeTmpDir` for the lifecycle:
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { access, readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { scaffold } from '../src/scaffold.js';
+import { makeTmpDir } from './helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULTS = {
+  projectName: 'test-project',
+  description: 'A test project',
+  authorName: 'Test Author',
+  authorEmail: 'test@example.com',
+  projectType: /** @type {'web'} */ ('web'),
+};
+
+describe('scaffold — web project', () => {
+  let tmpDir, outDir, cleanup;
+
+  beforeEach(async () => {
+    ({ tmpDir, cleanup } = await makeTmpDir('gulp-khup-web-'));
+    outDir = join(tmpDir, 'output');
+  });
+
+  afterEach(() => cleanup());
+
+  // Paste all `it(...)` cases from the web describe block here, unchanged.
+  // Replace manual `mkdtemp`/`rm` usages with the lifecycle above.
+});
+```
+
+Copy every `it(...)` from the existing web describe block verbatim.
+
+- [ ] **Step 3: Move wordpress-type tests to `test/scaffold-wordpress.test.js`**
+
+Same pattern as Step 2 — extract the `describe('scaffold — wordpress project', ...)` block:
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { access, readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { scaffold } from '../src/scaffold.js';
+import { makeTmpDir } from './helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULTS = {
+  projectName: 'test-project',
+  description: 'A test project',
+  authorName: 'Test Author',
+  authorEmail: 'test@example.com',
+  projectType: /** @type {'wordpress'} */ ('wordpress'),
+};
+
+describe('scaffold — wordpress project', () => {
+  let tmpDir, outDir, cleanup;
+
+  beforeEach(async () => {
+    ({ tmpDir, cleanup } = await makeTmpDir('gulp-khup-wp-'));
+    outDir = join(tmpDir, 'output');
+  });
+
+  afterEach(() => cleanup());
+
+  // Paste all it(...) cases from the wordpress describe block here.
+});
+```
+
+- [ ] **Step 4: Move email-type tests to `test/scaffold-email.test.js`**
+
+Same pattern — extract the `describe('scaffold — email project', ...)` block:
+
+```js
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { access, readFile } from 'fs/promises';
+import { join, dirname } from 'path';
+import { fileURLToPath } from 'url';
+import { scaffold } from '../src/scaffold.js';
+import { makeTmpDir } from './helpers.js';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+
+const DEFAULTS = {
+  projectName: 'test-project',
+  description: 'A test project',
+  authorName: 'Test Author',
+  authorEmail: 'test@example.com',
+  projectType: /** @type {'email'} */ ('email'),
+};
+
+describe('scaffold — email project', () => {
+  let tmpDir, outDir, cleanup;
+
+  beforeEach(async () => {
+    ({ tmpDir, cleanup } = await makeTmpDir('gulp-khup-email-'));
+    outDir = join(tmpDir, 'output');
+  });
+
+  afterEach(() => cleanup());
+
+  // Paste all it(...) cases from the email describe block here.
+});
+```
+
+- [ ] **Step 5: Trim `test/scaffold.test.js`**
+
+Keep only the pure-function blocks and directory-handling tests:
+- `describe('applyTokens', ...)` — keep as-is
+- `describe('resolveTemplateDirs', ...)` — keep as-is
+- `describe('scaffold — directory handling', ...)` — keep as-is
+
+Delete all web/wordpress/email type-specific describe blocks from this file.
+
+- [ ] **Step 6: Run tests — verify same count, all pass**
+
+```bash
+npm test
+```
+
+Expected: same number of tests as before (no tests lost or added), all pass.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add test/helpers.js test/scaffold-web.test.js test/scaffold-wordpress.test.js test/scaffold-email.test.js test/scaffold.test.js
+git commit -m "test: split scaffold.test.js into per-type files with shared mkdtemp helper"
+```
+
+---
+
+## Task 2: Fix B3 code quality bugs
+
+**Files:**
+- Modify: `templates/base/gulp/tasks/css.js`
+- Modify: `templates/base/package.json.tpl`
+- Modify: `templates/email/package.json.tpl`
+
+- [ ] **Step 1: Add a failing snapshot assertion for the `repository` field**
+
+In `test/scaffold-web.test.js`, add:
+
+```js
+it('generated package.json does not contain a repository URL field', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf-8'));
+  expect(pkg.repository).toBeUndefined();
+});
+```
+
+Add the same test to `test/scaffold-wordpress.test.js` and `test/scaffold-email.test.js`.
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'repository'
+```
+
+Expected: 3 new tests fail (repository field exists today).
+
+- [ ] **Step 3: Fix the `// bytes` comment in `css.js`**
+
+In `templates/base/gulp/tasks/css.js`:
+
+```js
+// Before:
+const INLINE_ASSET_MAX_SIZE = 8 * 1024; // bytes
+
+// After:
+const INLINE_ASSET_MAX_SIZE = 8 * 1024; // 8 KB
+```
+
+- [ ] **Step 4: Remove `repository` field from `templates/base/package.json.tpl`**
+
+Delete these 4 lines:
+
+```json
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/<%= appName %>"
+  },
+```
+
+- [ ] **Step 5: Remove `repository` field from `templates/email/package.json.tpl`**
+
+Same deletion in the email template.
+
+- [ ] **Step 6: Run tests — verify the repository tests now pass**
+
+```bash
+npm test
+```
+
+Expected: the 3 new `repository` tests pass. Snapshots may fail — do NOT update them yet (they will be regenerated in Task 7 after all manifest changes).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/base/gulp/tasks/css.js templates/base/package.json.tpl templates/email/package.json.tpl test/scaffold-web.test.js test/scaffold-wordpress.test.js test/scaffold-email.test.js
+git commit -m "fix: remove repository field from package.json.tpl; fix css.js 8 KB comment"
+```
+
+---
+
+## Task 3: Replace `through2` with native `Transform`
+
+**Files:**
+- Modify: `templates/base/gulp/tasks/css.js`
+- Modify: `templates/base/gulp/tasks/js.js`
+- Modify: `templates/base/gulp/tasks/img.js`
+- Modify: `templates/base/gulp/tasks/html.js`
+
+The pattern is mechanical: replace `import through from 'through2'` (or `import through2 from 'through2'`) with `import { Transform } from 'node:stream'`, then replace every `through.obj(function(file, _, cb) {...})` or `through2.obj((file, _, cb) => {...})` with `new Transform({ objectMode: true, transform(file, _, cb) {...} })`.
+
+These changes are verified by the integration smoke test (`gulp build`), not by unit tests.
+
+- [ ] **Step 1: Update `templates/base/gulp/tasks/img.js`**
+
+```js
+// Remove:
+import through2 from 'through2';
+
+// Add:
+import { Transform } from 'node:stream';
+
+// Replace every through2.obj call:
+// Before:
+const optimizeImage = () =>
+  through2.obj((file, _, cb) => {
+    // ...body unchanged...
+  });
+
+// After:
+const optimizeImage = () =>
+  new Transform({
+    objectMode: true,
+    transform(file, _, cb) {
+      // ...body unchanged...
+    },
+  });
+```
+
+- [ ] **Step 2: Update `templates/base/gulp/tasks/html.js`**
+
+```js
+// Remove:
+import through2 from 'through2';
+
+// Add:
+import { Transform } from 'node:stream';
+
+// Replace through2.obj calls with new Transform({ objectMode: true, transform(file, _, cb) {...} })
+// Body of each transform function is unchanged.
+```
+
+- [ ] **Step 3: Update `templates/base/gulp/tasks/js.js`**
+
+```js
+// Remove:
+import through from 'through2';
+
+// Add:
+import { Transform } from 'node:stream';
+
+// Replace:
+// Before:
+const bundleWithEsbuild = () => {
+  return through.obj(function transform(file, _enc, cb) {
+    const stream = this;
+    // ...body unchanged...
+  });
+};
+
+// After:
+const bundleWithEsbuild = () => {
+  return new Transform({
+    objectMode: true,
+    transform(file, _enc, cb) {
+      const stream = this;
+      // ...body unchanged...
+    },
+  });
+};
+```
+
+- [ ] **Step 4: Update `templates/base/gulp/tasks/css.js`**
+
+Same pattern — remove `through` import, add `Transform` from `node:stream`, replace all `through.obj(...)` / `through2.obj(...)` calls.
+
+- [ ] **Step 5: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all pass. The task files themselves are not unit-tested (only their existence is checked), so the test suite output is unchanged. Full integration verification happens in CI.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/base/gulp/tasks/css.js templates/base/gulp/tasks/js.js templates/base/gulp/tasks/img.js templates/base/gulp/tasks/html.js
+git commit -m "fix: replace through2 with native node:stream Transform in all base task files"
+```
+
+---
+
+## Task 4: Replace `gulp-touch-cmd` with inline `utimes`
+
+**Files:**
+- Modify: `templates/base/gulp/tasks/js.js`
+
+- [ ] **Step 1: Update `js.js`**
+
+```js
+// Remove:
+import touch from 'gulp-touch-cmd';
+
+// Add at top with other node: imports:
+import { utimes } from 'node:fs/promises';
+import { Transform } from 'node:stream'; // (already added in Task 3)
+
+// Add this helper function after the imports:
+const touchFile = () =>
+  new Transform({
+    objectMode: true,
+    transform(file, _, cb) {
+      const now = new Date();
+      utimes(file.path, now, now)
+        .then(() => cb(null, file))
+        .catch(() => cb(null, file)); // silently skip if file doesn't exist yet
+    },
+  });
+
+// In jsTask, replace:
+    .pipe(touch())
+// With:
+    .pipe(touchFile())
+```
+
+- [ ] **Step 2: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 3: Commit**
+
+```bash
+git add templates/base/gulp/tasks/js.js
+git commit -m "fix: replace gulp-touch-cmd 0.0.1 with inline fs.utimes Transform in js.js"
+```
+
+---
+
+## Task 5: Replace `gulp-special-html` with inline entity Transform
+
+**Files:**
+- Modify: `templates/base/gulp/tasks/html.js`
+
+`gulp-special-html` converts a small set of special characters to named HTML entities. Examine its source at `node_modules/gulp-special-html/index.js` to capture the exact entity map, then inline it.
+
+- [ ] **Step 1: Inspect the package source**
+
+```bash
+cat node_modules/gulp-special-html/index.js
+```
+
+Note the entity substitutions it performs (typically: `©` → `&copy;`, `®` → `&reg;`, `™` → `&trade;`, `–` → `&ndash;`, `—` → `&mdash;`). Record the full map.
+
+- [ ] **Step 2: Update `html.js`**
+
+```js
+// Remove:
+import special from 'gulp-special-html';
+
+// Add (use the exact entity map from the package source):
+import { Transform } from 'node:stream'; // already present from Task 3
+
+const ENTITY_MAP = new Map([
+  ['©', '&copy;'],
+  ['®', '&reg;'],
+  ['™', '&trade;'],
+  // Add any additional entries observed in the package source
+]);
+
+const fixSpecialChars = () =>
+  new Transform({
+    objectMode: true,
+    transform(file, _, cb) {
+      if (file.isNull()) { cb(null, file); return; }
+      let content = file.contents.toString('utf-8');
+      for (const [char, entity] of ENTITY_MAP) {
+        content = content.replaceAll(char, entity);
+      }
+      file.contents = Buffer.from(content, 'utf-8');
+      cb(null, file);
+    },
+  });
+
+// In htmlTask pipeline, replace:
+    .pipe(special())
+// With:
+    .pipe(fixSpecialChars())
+```
+
+- [ ] **Step 3: Run tests**
+
+```bash
+npm test
+```
+
+Expected: all pass.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add templates/base/gulp/tasks/html.js
+git commit -m "fix: replace gulp-special-html 0.0.4 with inline entity-correction Transform in html.js"
+```
+
+---
+
+## Task 6: Remove deprecated `fastclick` and audit moderate vulns
+
+**Files:**
+- Modify: `templates/base/package.json.tpl`
+
+- [ ] **Step 1: Add a failing test**
+
+In `test/scaffold-web.test.js`, add:
+
+```js
+it('generated package.json does not include fastclick', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).not.toContain('fastclick');
+});
+```
+
+- [ ] **Step 2: Run test — verify it fails**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep fastclick
+```
+
+- [ ] **Step 3: Remove `fastclick` from `templates/base/package.json.tpl`**
+
+Delete this line from `"dependencies"`:
+
+```json
+    "fastclick": "^1.0.6",
+```
+
+- [ ] **Step 4: Run tests — verify the fastclick test passes**
+
+```bash
+npm test
+```
+
+- [ ] **Step 5: Audit moderate vulns in a scaffolded web project**
+
+```bash
+mkdir /tmp/audit-test && cd /tmp/audit-test
+node --input-type=module <<'EOF'
+import { scaffold } from '/Users/richard.deslauriers/_code/gulp-khup/src/scaffold.js';
+await scaffold({
+  projectName: 'audit-test',
+  description: 'audit',
+  authorName: 'CI',
+  authorEmail: 'ci@example.com',
+  projectType: 'web',
+  cwd: '/tmp/audit-test',
+});
+EOF
+cd /tmp/audit-test/audit-test && npm install --legacy-peer-deps 2>/dev/null
+npm audit 2>&1 | tail -20
+cd / && rm -rf /tmp/audit-test
+```
+
+Review the output. For each moderate vulnerability, add an entry to the `"overrides"` section of `templates/base/package.json.tpl` (and `templates/web/package.json.tpl` in Task 7 which will supersede base). Example pattern:
+
+```json
+  "overrides": {
+    "existing-key": "^existing-version",
+    "new-vuln-package": "^fixed-version"
+  }
+```
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add templates/base/package.json.tpl test/scaffold-web.test.js
+git commit -m "fix: remove deprecated fastclick dep; address moderate audit vulns"
+```
+
+---
+
+## Task 7: Create `templates/web/package.json.tpl`
+
+**Files:**
+- Create: `templates/web/package.json.tpl`
+- Modify: `templates/base/package.json.tpl`
+
+The web `package.json.tpl` completely replaces the base one during scaffold (same mechanism as email today). It must be a self-contained complete file.
+
+- [ ] **Step 1: Add failing assertions for web-only deps**
+
+In `test/scaffold-web.test.js`, add:
+
+```js
+it('generated web package.json includes stylelint', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).toContain('stylelint');
+});
+
+it('generated web package.json includes ssh2-sftp-client', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).toContain('ssh2-sftp-client');
+});
+
+it('generated web package.json includes normalize.css as a runtime dep', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf-8'));
+  expect(pkg.dependencies?.['normalize.css']).toBeDefined();
+});
+```
+
+- [ ] **Step 2: Add assertions that verify these deps are NOT in base (used by other types)**
+
+In `test/scaffold-wordpress.test.js`, add:
+
+```js
+it('generated wordpress package.json does not include normalize.css', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const pkg = JSON.parse(await readFile(join(outDir, 'package.json'), 'utf-8'));
+  expect(pkg.dependencies?.['normalize.css']).toBeUndefined();
+});
+```
+
+In `test/scaffold-email.test.js`, add:
+
+```js
+it('generated email package.json does not include stylelint', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).not.toContain('stylelint');
+});
+```
+
+- [ ] **Step 3: Run tests — verify new assertions fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'FAIL|stylelint|normalize|sftp'
+```
+
+- [ ] **Step 4: Create `templates/web/package.json.tpl`**
+
+Copy `templates/base/package.json.tpl` as a starting point, then add web-only deps and sections. The file must contain the complete set of deps (base + web):
+
+Deps to add vs. base:
+- `devDependencies`: `"stylelint"`, `"stylelint-config-standard"`, `"stylelint-order"`, `"stylelint-scss"`, `"ssh2-sftp-client"`, `"nunjucks"`, `"nunjucks-markdown"`, `"marked"`, `"gulp-nunjucks"`, `"gulp-inline-source"`
+- `dependencies` section (new): `"basiclightbox"`, `"hamburgers"`, `"normalize.css"`, `"swiper"` (copy current values from base `"dependencies"`, without `"fastclick"`)
+
+Example structure:
+
+```json
+{
+  "name": "<%= appName %>",
+  "description": "<%= appDescription %>",
+  "version": "<%= appVersion %>",
+  "main": "./gulpfile.js",
+  "private": true,
+  "author": {
+    "name": "<%= authorName %>",
+    "email": "<%= authorEmail %>"
+  },
+  "type": "module",
+  "license": "MIT",
+  "scripts": {
+    "check": "biome check .",
+    "format": "biome format --write .",
+    "lint": "biome lint ."
+  },
+  "devDependencies": {
+    "@biomejs/biome": "^2.2.4",
+    "autoprefixer": "^10.4.21",
+    "beeper": "^3.0.0",
+    "browser-sync": "^3.0.4",
+    "chalk": "^5.6.2",
+    "cssnano": "^7.1.1",
+    "del": "^8.0.1",
+    "dotenv": "^17.2.2",
+    "esbuild": "^0.25.10",
+    "gulp": "^5.0.1",
+    "gulp-cached": "^1.1.1",
+    "gulp-changed": "^5.0.3",
+    "gulp-flatmap": "^1.0.2",
+    "html-minifier-terser": "^7.2.0",
+    "gulp-inline-source": "^4.0.0",
+    "gulp-notify": "^5.0.0",
+    "gulp-nunjucks": "^6.1.0",
+    "gulp-plumber": "^1.2.1",
+    "gulp-postcss": "^10.0.0",
+    "gulp-pxtorem": "^3.0.0",
+    "gulp-rename": "^2.1.0",
+    "gulp-replace": "^1.1.4",
+    "gulp-sass": "^6.0.1",
+    "gulp-size": "^5.0.0",
+    "gulp-sourcemaps": "^3.0.0",
+    "marked": "^16.3.0",
+    "nunjucks": "^3.2.4",
+    "nunjucks-markdown": "^2.0.1",
+    "postcss": "^8.5.10",
+    "sass": "^1.93.2",
+    "sharp": "^0.34.0",
+    "ssh2-sftp-client": "^12.0.1",
+    "stylelint": "^16.24.0",
+    "stylelint-config-standard": "^39.0.0",
+    "stylelint-order": "^7.0.0",
+    "stylelint-scss": "^6.12.1",
+    "svgo": "^3.3.2"
+  },
+  "dependencies": {
+    "basiclightbox": "^5.0.4",
+    "hamburgers": "^1.2.1",
+    "normalize.css": "^8.0.1",
+    "swiper": "^12.0.2"
+  },
+  "overrides": {
+    "lodash.template": "^4.5.0",
+    "nth-check": "^2.1.1",
+    "terser": "^5.0.0",
+    "uuid": "^11.1.1"
+  }
+}
+```
+
+Use the exact version strings from the current `base/package.json.tpl` — do not invent new version numbers.
+
+- [ ] **Step 5: Strip web-only deps from `templates/base/package.json.tpl`**
+
+Remove from base:
+- `devDependencies`: `stylelint`, `stylelint-config-standard`, `stylelint-order`, `stylelint-scss`, `ssh2-sftp-client`, `nunjucks`, `nunjucks-markdown`, `marked`, `gulp-nunjucks`, `gulp-inline-source`
+- Entire `"dependencies"` section (frontend runtime libs)
+
+- [ ] **Step 6: Run tests — verify assertions pass**
+
+```bash
+npm test
+```
+
+Expected: the new dep-split assertions pass. Some snapshot tests will fail — skip `--update` for now.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add templates/web/package.json.tpl templates/base/package.json.tpl test/scaffold-web.test.js test/scaffold-wordpress.test.js test/scaffold-email.test.js
+git commit -m "feat: add web/package.json.tpl — web-only deps split from base"
+```
+
+---
+
+## Task 8: Create `templates/wordpress/package.json.tpl`
+
+**Files:**
+- Create: `templates/wordpress/package.json.tpl`
+
+- [ ] **Step 1: Add failing assertions for wordpress-specific deps**
+
+In `test/scaffold-wordpress.test.js`, add:
+
+```js
+it('generated wordpress package.json includes stylelint', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).toContain('stylelint');
+});
+
+it('generated wordpress package.json includes ssh2-sftp-client', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).toContain('ssh2-sftp-client');
+});
+
+it('generated wordpress package.json does not include nunjucks', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).not.toContain('"nunjucks"');
+});
+
+it('generated wordpress package.json does not include gulp-inline-source', async () => {
+  await scaffold({ ...DEFAULTS, outDir });
+  const content = await readFile(join(outDir, 'package.json'), 'utf-8');
+  expect(content).not.toContain('gulp-inline-source');
+});
+```
+
+- [ ] **Step 2: Run tests — verify they fail**
+
+```bash
+npm test -- --reporter=verbose 2>&1 | grep -E 'FAIL|wordpress.*stylelint|wordpress.*nunjucks'
+```
+
+- [ ] **Step 3: Create `templates/wordpress/package.json.tpl`**
+
+Copy `templates/base/package.json.tpl` (the already-trimmed base) as a starting point and add wordpress-specific deps:
+
+Deps to add vs. trimmed base:
+- `devDependencies`: `"stylelint"`, `"stylelint-config-standard"`, `"stylelint-order"`, `"stylelint-scss"`, `"ssh2-sftp-client"`
+
+No `"dependencies"` section (WordPress themes do not install frontend libs via npm in this setup).
+
+Use the same version strings as in `templates/web/package.json.tpl`.
+
+- [ ] **Step 4: Run tests — verify assertions pass**
+
+```bash
+npm test
+```
+
+Expected: all new assertions pass.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add templates/wordpress/package.json.tpl test/scaffold-wordpress.test.js
+git commit -m "feat: add wordpress/package.json.tpl — wordpress-only deps split from base"
+```
+
+---
+
+## Task 9: Regenerate snapshots and run full verification
+
+**Files:**
+- Update: `test/__snapshots__/*.snap`
+
+- [ ] **Step 1: Update all snapshots**
+
+```bash
+npx vitest run -u
+```
+
+Expected: snapshot files updated to reflect: removed `repository` field, removed web-only deps from base, `through2`/`gulp-touch-cmd`/`gulp-special-html`/`fastclick` absent from `package.json` outputs.
+
+- [ ] **Step 2: Review the snapshot diff**
+
+```bash
+git diff test/__snapshots__/
+```
+
+Verify the diff shows only expected removals (the deps and fields listed above) and no unexpected changes.
+
+- [ ] **Step 3: Run full test suite with coverage**
+
+```bash
+npm run test:coverage
+```
+
+Expected: exits 0, all tests pass, 100% coverage on `src/`.
+
+- [ ] **Step 4: Run type check**
+
+```bash
+npx tsc --project jsconfig.json --noEmit
+```
+
+Expected: exits 0.
+
+- [ ] **Step 5: Commit snapshots**
+
+```bash
+git add test/__snapshots__/
+git commit -m "test: update snapshots after template dep split and dependency cleanup"
+```
+
+- [ ] **Step 6: Update CHANGELOG and bump version**
+
+Bump to `1.5.0` in `package.json` and update `CHANGELOG.md` `[Unreleased]`:
+
+```markdown
+## [Unreleased]
+
+### Added
+- `templates/web/package.json.tpl` — web project type now gets only its required deps
+- `templates/wordpress/package.json.tpl` — WordPress project type now gets only its required deps
+
+### Changed
+- `through2` replaced with native `node:stream` `Transform` in all base task files
+- `gulp-touch-cmd 0.0.1` replaced with inline `fs.utimes` Transform in `js.js`
+- `gulp-special-html 0.0.4` replaced with inline entity-correction Transform in `html.js`
+- Generated `package.json` no longer includes a `repository` field (was always incomplete)
+- `css.js` comment corrected: `// bytes` → `// 8 KB`
+
+### Removed
+- `fastclick` removed from generated web project (deprecated since iOS 8)
+```
+
+- [ ] **Step 7: Open PR**
+
+```bash
+git push -u origin feat/<issue>-template-quality
+```
+
+Open PR targeting `main`. Title: `feat: template dep split, replace unmaintained packages, code quality fixes`.

--- a/docs/superpowers/specs/2026-07-18-repo-improvements-design.md
+++ b/docs/superpowers/specs/2026-07-18-repo-improvements-design.md
@@ -1,0 +1,164 @@
+# Repo Improvements Design
+
+**Date:** 2026-07-18
+**Scope:** Three focused PRs — scaffolder core (A), template quality (B), repo DX (D)
+**Approach:** Approach 1 — three independent PRs, one per area; merged sequentially
+
+---
+
+## Area A — Scaffolder Core
+
+### A1 — Non-interactive / flag mode
+
+`bin/create.js` gains CLI flag parsing via `util.parseArgs` (Node 18+ built-in, zero new deps).
+
+**New flags:**
+
+| Flag | Short | Behaviour |
+|------|-------|-----------|
+| `--version` | `-v` | Read version from `package.json` via `readFile` + `JSON.parse`, print, exit 0 |
+| `--help` | `-h` | Print usage summary, exit 0 |
+| `--type` | | Accept `web\|wordpress\|email`; print error + exit 1 if invalid value supplied |
+| `--description` | | Pre-fill or set the description field |
+| `--yes` | `-y` | Skip all prompts; requires a positional project name arg |
+
+**`--yes` mode behaviour:** build `ScaffoldValues` directly without calling `promptUser`:
+- `projectName` — from positional arg (required; error + exit 1 if absent)
+- `projectType` — from `--type` (default: `web`)
+- `description` — from `--description` (default: `''`)
+- `authorName` / `authorEmail` — from `getGitConfig` (already exported from `cli.js`)
+
+**Without `--yes`:** any flags supplied pre-fill their corresponding prompts. `promptUser` gains an `initialValues` parameter (object) replacing the current `initialName` string.
+
+### A2 — CLI hygiene
+
+`--version`/`-v` and `--help`/`-h` are handled at the top of `bin/create.js` before `promptUser` is called. Version is read dynamically from `package.json` using `readFile` + `JSON.parse` with `import.meta.url` resolution — no `require`, no JSON import assertion.
+
+### A3 — Validation fixes
+
+`validateProjectName` in `src/cli.js` updated:
+
+- **Character class:** `[a-zA-Z0-9_-]` → `[a-z0-9_-]` — reject uppercase (package names must be lowercase; `sanitizeProjectName` already lowercases but the validator should be consistent)
+- **Leading character:** reject names starting with `-` or `_` (npm disallows both)
+- **Length:** reject names over 214 characters (npm limit)
+
+The space→hyphen replacement in `sanitizeProjectName` becomes unreachable (spaces are already rejected by the validator) and is removed.
+
+### A — Testing
+
+New / updated test cases:
+- `bin.test.js`: structural check includes new flags in `--help` output
+- `cli.test.js`: updated `validateProjectName` rules (uppercase rejected, leading `-`/`_` rejected, length limit)
+- `cli-prompt.test.js`: `promptUser` accepts `initialValues` object; each field pre-fills correctly
+- `cli.test.js`: `sanitizeProjectName` no longer replaces spaces (dead code removed)
+
+---
+
+## Area B — Template Quality
+
+### B1 — Dependency hygiene
+
+Four targeted replacements; each removes a pinned or unmaintained package from all `package.json.tpl` files.
+
+**`through2` → `node:stream` `Transform`**
+Used in `css.js`, `js.js`, `img.js`, `html.js`. Replaced with `new Transform({ objectMode: true, transform(file, _, cb) { … } })` — same pattern, zero deps. `through2` removed from all `package.json.tpl` files.
+
+**`gulp-touch-cmd 0.0.1` → inline `fs.utimes`**
+Used only in `js.js` to update file mtime after bundling. Replace with a 3-line Transform that calls `fs.utimes(file.path, now, now)`. `gulp-touch-cmd` removed from all `package.json.tpl` files.
+
+**`gulp-special-html 0.0.4` → inline entity-correction Transform**
+Used only in `html.js` (base). Replace with an inline Transform that applies the same entity substitutions. `gulp-special-html` removed from all `package.json.tpl` files.
+
+**`fastclick` removed**
+Present in base `package.json.tpl` `dependencies`. Deprecated since iOS 8 / Chrome 32 (click delay no longer exists in modern browsers). Removed with no replacement.
+
+**Moderate vulnerabilities**
+After the above removals, scaffold a web project, run `npm audit`, and apply additional `overrides` or dep bumps as needed to address the 5 remaining moderate vulns.
+
+### B2 — Per-type dep splitting
+
+The scaffold merge (`base/` → `<type>/`) means a type-specific `package.json.tpl` **replaces** the base file entirely. Creating `web/package.json.tpl` and `wordpress/package.json.tpl` allows each type to carry exactly the deps it needs.
+
+**New files:**
+
+The scaffold merge replaces the base `package.json.tpl` entirely with the type-specific file (same behaviour as `email/package.json.tpl` today). Each new file must therefore be a complete, self-contained `package.json.tpl` — not just a delta.
+
+- `templates/web/package.json.tpl` — complete file; base shared deps + `stylelint` stack, `ssh2-sftp-client`, `nunjucks`/`nunjucks-markdown`/`marked`/`gulp-nunjucks`, `gulp-inline-source`; `dependencies`: `basiclightbox`, `hamburgers`, `normalize.css`, `swiper`
+- `templates/wordpress/package.json.tpl` — complete file; base shared deps + `stylelint` stack, `ssh2-sftp-client`; excludes: `nunjucks` stack, `gulp-inline-source`, `gulp-inline-css`, and all frontend runtime `dependencies`
+
+**`templates/base/package.json.tpl` after split:** retains only truly shared deps — gulp core, css/js/img/html tooling (`sass`, `gulp-sass`, `esbuild`, `autoprefixer`, `cssnano`, `postcss`, `sharp`, `svgo`, `html-minifier-terser`, `gulp-postcss`, `gulp-pxtorem`, `gulp-flatmap`, `gulp-sourcemaps`, `gulp-rename`, `gulp-replace`, `gulp-cached`, `gulp-changed`, `gulp-notify`, `gulp-size`, `gulp-plumber`), `biome`, `browser-sync`, `beeper`, `chalk`, `del`, `dotenv`. No `dependencies` section (web-only). The type-specific `package.json.tpl` files duplicate the base dep list — this is intentional and matches how `email/package.json.tpl` already works.
+
+**`templates/email/package.json.tpl`:** already exists and already excludes `stylelint` and `ssh2-sftp-client`. Trim `gulp-inline-source` and `gulp-flatmap` if email tasks don't use them; verify during implementation.
+
+**Dep matrix:**
+
+| Dep group | base | web | wordpress | email |
+|---|---|---|---|---|
+| `stylelint` stack | removed | ✓ | ✓ | — |
+| `ssh2-sftp-client` | removed | ✓ | ✓ | — |
+| `nunjucks`/`marked`/`gulp-nunjucks` | removed | ✓ | — | ✓ (existing) |
+| `gulp-inline-source` | removed | ✓ | — | — |
+| `gulp-flatmap` | stays | ✓ | ✓ | ✓ |
+| `basiclightbox`, `hamburgers`, etc. | removed | ✓ | — | — |
+| `fastclick` | removed | — | — | — |
+
+### B3 — Generated code quality
+
+Two targeted fixes:
+
+1. **`css.js` comment bug:** `const INLINE_ASSET_MAX_SIZE = 8 * 1024; // bytes` → `// 8 KB` (8 × 1024 = 8192, not 8)
+2. **`repository` field in all `package.json.tpl` files:** `"url": "https://github.com/<%= appName %>"` has no username — the URL is always incomplete. Remove the `repository` field entirely from all `package.json.tpl` files. It is optional in `package.json`; users can add it after scaffolding.
+
+### B — Testing
+
+- Snapshot tests for `gulpfile.js` and `package.json` will need updating — run `vitest run -u`
+- New file-existence assertions for `web/package.json.tpl`-sourced deps in web output
+- Assertions that wordpress output does NOT contain `nunjucks` in its `package.json`
+- Assertions that email output does NOT contain `stylelint` in its `package.json` (already passing; keep as regression guard)
+
+---
+
+## Area D — Repo DX
+
+### D1 — CI efficiency
+
+**Redundant test step:** the `test` job currently runs `npm test` then `npm run test:coverage` as two separate steps. Both run the full test suite. Drop the `npm test` step; keep only `npm run test:coverage`. Tests still run, coverage is captured in one pass. Applies to both Node 18 and Node 22 matrix legs — halves test time.
+
+**`--legacy-peer-deps` flags:** after B1/B2 cleans up the generated project dep tree, the integration job's `npm install --legacy-peer-deps` is re-evaluated and removed if no longer needed. The scaffolder's own `npm ci --legacy-peer-deps` is investigated — likely caused by `typescript ^7.0.2` vs. a vitest peer dep — and removed if resolvable.
+
+### D2 — Test organisation
+
+During B work, `scaffold.test.js` (599 lines) is split into three focused files:
+
+- `scaffold-web.test.js` — web-type file-existence, token substitution, and snapshot tests
+- `scaffold-wordpress.test.js` — wordpress-type tests
+- `scaffold-email.test.js` — email-type tests
+
+A shared `createTmpDir` / `cleanupTmpDir` helper is extracted (or placed in a small `test/helpers.js`) to avoid repeating the `mkdtemp`/`rm` lifecycle in each file. The existing `scaffold-errors.test.js`, `cli.test.js`, `cli-prompt.test.js`, `bin.test.js`, and `package.test.js` are unchanged.
+
+Target: each new file ~150–200 lines. Total test count remains the same.
+
+### D3 — Dev tooling
+
+The scaffolder source (`src/`, `bin/`, `test/`) has no linter today. Fix:
+
+1. Add `@biomejs/biome` to scaffolder `devDependencies`
+2. Add `biome.json` to repo root (conservative config, matches the template `biome.json` where possible)
+3. Add `"lint": "biome check ."` and `"format": "biome format --write ."` to scaffolder `package.json` scripts
+4. Add a lint step to the `typecheck` CI job — that job already installs deps and costs near-zero extra time
+
+No husky or lint-staged — single-maintainer repo, YAGNI.
+
+---
+
+## Delivery
+
+Three PRs, one per area, targeting `main`:
+
+| PR | Branch | Semver bump |
+|---|---|---|
+| Scaffolder core | `feat/<n>-scaffolder-core` | minor (new `--yes`, `--type`, `--help`, `--version` flags) |
+| Template quality | `feat/<n>-template-quality` | minor (generated projects change meaningfully) |
+| Repo DX | `chore/repo-dx` | none (no user-facing changes) |
+
+Merge order: A → B → D. B depends on A being stable (test helpers may be shared). D is independent but benefits from B's test reorganisation landing first.

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "create-gulp-khup",
   "description": "Scaffold a Gulp 5 static-site project — npm create gulp-khup@latest my-project",
-  "version": "1.3.1",
+  "version": "1.4.0",
   "type": "module",
   "bin": {
     "create-gulp-khup": "bin/create.js"

--- a/src/cli.js
+++ b/src/cli.js
@@ -64,15 +64,23 @@ export async function getGitConfig(key) {
 /**
  * Run the interactive \@clack/prompts flow and return the collected values.
  * Ctrl+C exits cleanly with a message — no stack trace.
- * @param {string} [initialName=''] - Pre-fill the project name prompt
+ * @param {{ projectName?: string, description?: string, projectType?: ProjectType, authorName?: string, authorEmail?: string }} [initialValues={}] - Pre-fill values for any prompt field
  * @returns {Promise<ScaffoldValues>}
  */
-export async function promptUser(initialName = '') {
+export async function promptUser(initialValues = {}) {
+  const {
+    projectName: initialName = '',
+    description: initialDescription = '',
+    projectType: initialProjectType,
+    authorName: prefilledAuthorName,
+    authorEmail: prefilledAuthorEmail,
+  } = initialValues;
+
   const p = await import('@clack/prompts');
 
   p.intro('create-gulp-khup');
 
-  const [authorName, authorEmail] = await Promise.all([
+  const [gitAuthorName, gitAuthorEmail] = await Promise.all([
     getGitConfig('user.name'),
     getGitConfig('user.email'),
   ]);
@@ -89,20 +97,22 @@ export async function promptUser(initialName = '') {
         p.text({
           message: 'Short description?',
           placeholder: 'A static marketing site',
+          initialValue: initialDescription,
         }),
       authorName: () =>
         p.text({
           message: 'Author name?',
-          initialValue: authorName,
+          initialValue: prefilledAuthorName ?? gitAuthorName,
         }),
       authorEmail: () =>
         p.text({
           message: 'Author email?',
-          initialValue: authorEmail,
+          initialValue: prefilledAuthorEmail ?? gitAuthorEmail,
         }),
       projectType: () =>
         p.select({
           message: 'Project type?',
+          initialValue: initialProjectType,
           options: [
             { value: 'web', label: 'Static HTML', hint: 'recommended' },
             { value: 'wordpress', label: 'WordPress' },

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,11 +26,11 @@ export function validateProjectName(name) {
   if (trimmed.includes('..') || trimmed.startsWith('/')) {
     return 'Invalid project name: path traversal is not allowed';
   }
-  if (trimmed.length > 214) {
-    return 'Invalid project name: must be 214 characters or fewer';
-  }
   if (!/^[a-z0-9][a-z0-9_-]*$/.test(trimmed)) {
     return 'Invalid project name: use only lowercase letters, numbers, hyphens, and underscores; must start with a letter or number';
+  }
+  if (trimmed.length > 214) {
+    return 'Invalid project name: must be 214 characters or fewer';
   }
   return undefined;
 }

--- a/src/cli.js
+++ b/src/cli.js
@@ -26,8 +26,11 @@ export function validateProjectName(name) {
   if (trimmed.includes('..') || trimmed.startsWith('/')) {
     return 'Invalid project name: path traversal is not allowed';
   }
-  if (!/^[a-zA-Z0-9_-]+$/.test(trimmed)) {
-    return 'Invalid project name: use only letters, numbers, hyphens, and underscores';
+  if (trimmed.length > 214) {
+    return 'Invalid project name: must be 214 characters or fewer';
+  }
+  if (!/^[a-z0-9][a-z0-9_-]*$/.test(trimmed)) {
+    return 'Invalid project name: use only lowercase letters, numbers, hyphens, and underscores; must start with a letter or number';
   }
   return undefined;
 }

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -25,6 +25,10 @@ describe('bin/create.js', () => {
     expect(source).toContain('sanitizeProjectName');
   });
 
+  it('calls validateProjectName on the project name in --yes mode', () => {
+    expect(source).toContain('validateProjectName');
+  });
+
   it('imports scaffold from src/scaffold.js', () => {
     expect(source).toContain("from '../src/scaffold.js'");
     expect(source).toContain('scaffold');

--- a/test/bin.test.js
+++ b/test/bin.test.js
@@ -34,12 +34,42 @@ describe('bin/create.js', () => {
     expect(source).toContain("from '@clack/prompts'");
   });
 
-  it('reads the CLI argument from process.argv[2]', () => {
-    expect(source).toContain('process.argv[2]');
+  it('reads CLI arguments from process.argv', () => {
+    expect(source).toContain('process.argv.slice(2)');
   });
 
   it('handles scaffold errors with p.log.error and process.exit(1)', () => {
     expect(source).toContain('process.exit(1)');
     expect(source).toContain('p.log.error');
+  });
+
+  it('imports parseArgs from node:util', () => {
+    expect(source).toContain("from 'node:util'");
+    expect(source).toContain('parseArgs');
+  });
+
+  it('handles the --version flag', () => {
+    expect(source).toContain('flags.version');
+    expect(source).toContain('pkg.version');
+  });
+
+  it('handles the --help flag', () => {
+    expect(source).toContain('flags.help');
+    expect(source).toContain('--type');
+    expect(source).toContain('--yes');
+    expect(source).toContain('--version');
+  });
+
+  it('handles the --yes flag for non-interactive mode', () => {
+    expect(source).toContain('flags.yes');
+    expect(source).toContain('getGitConfig');
+  });
+
+  it('validates --type against VALID_TYPES', () => {
+    expect(source).toContain('VALID_TYPES');
+  });
+
+  it('imports getGitConfig from src/cli.js', () => {
+    expect(source).toContain('getGitConfig');
   });
 });

--- a/test/cli-prompt.test.js
+++ b/test/cli-prompt.test.js
@@ -138,4 +138,15 @@ describe('promptUser', () => {
       expect.objectContaining({ initialValue: 'override@example.com' })
     );
   });
+
+  it('passes initialValues.projectType as initialValue to the projectType prompt', async () => {
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      await fieldsObj.projectType();
+      return mockValues;
+    });
+    await promptUser({ projectType: 'wordpress' });
+    expect(p.select).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: 'wordpress' })
+    );
+  });
 });

--- a/test/cli-prompt.test.js
+++ b/test/cli-prompt.test.js
@@ -95,11 +95,6 @@ describe('promptUser', () => {
     exitSpy.mockRestore();
   });
 
-  it('accepts an initialValues object (no error thrown with object arg)', async () => {
-    p.group.mockResolvedValueOnce(mockValues);
-    await expect(promptUser({ projectName: 'init-name' })).resolves.toBeDefined();
-  });
-
   it('passes initialValues.projectName as initialValue to the projectName prompt', async () => {
     p.group.mockImplementationOnce(async (fieldsObj) => {
       await fieldsObj.projectName();
@@ -119,6 +114,28 @@ describe('promptUser', () => {
     await promptUser({ description: 'pre-filled desc' });
     expect(p.text).toHaveBeenCalledWith(
       expect.objectContaining({ initialValue: 'pre-filled desc' })
+    );
+  });
+
+  it('passes initialValues.authorName as initialValue to the authorName prompt', async () => {
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      await fieldsObj.authorName();
+      return mockValues;
+    });
+    await promptUser({ authorName: 'Override Author' });
+    expect(p.text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: 'Override Author' })
+    );
+  });
+
+  it('passes initialValues.authorEmail as initialValue to the authorEmail prompt', async () => {
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      await fieldsObj.authorEmail();
+      return mockValues;
+    });
+    await promptUser({ authorEmail: 'override@example.com' });
+    expect(p.text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: 'override@example.com' })
     );
   });
 });

--- a/test/cli-prompt.test.js
+++ b/test/cli-prompt.test.js
@@ -33,25 +33,25 @@ afterEach(() => {
 describe('promptUser', () => {
   it('calls p.intro with the package name', async () => {
     p.group.mockResolvedValueOnce(mockValues);
-    await promptUser('');
+    await promptUser({});
     expect(p.intro).toHaveBeenCalledWith('create-gulp-khup');
   });
 
   it('calls p.group to collect project details', async () => {
     p.group.mockResolvedValueOnce(mockValues);
-    await promptUser('');
+    await promptUser({});
     expect(p.group).toHaveBeenCalledOnce();
   });
 
   it('returns the values from p.group', async () => {
     p.group.mockResolvedValueOnce(mockValues);
-    const result = await promptUser('');
+    const result = await promptUser({});
     expect(result).toEqual(mockValues);
   });
 
   it('passes initialName as initialValue for the projectName prompt', async () => {
     p.group.mockResolvedValueOnce(mockValues);
-    await promptUser('pre-filled-name');
+    await promptUser({ projectName: 'pre-filled-name' });
 
     // p.group is called with (fieldsObject, options)
     // The fields object is the first arg — each field is a function
@@ -69,7 +69,7 @@ describe('promptUser', () => {
       return mockValues;
     });
 
-    await promptUser('my-project');
+    await promptUser({ projectName: 'my-project' });
 
     // p.text called for projectName, description, authorName, authorEmail (4×)
     expect(p.text).toHaveBeenCalledTimes(4);
@@ -87,11 +87,38 @@ describe('promptUser', () => {
       throw new Error('process.exit called');
     });
 
-    await expect(promptUser('')).rejects.toThrow('process.exit called');
+    await expect(promptUser({})).rejects.toThrow('process.exit called');
 
     expect(p.cancel).toHaveBeenCalledWith('Cancelled — no files were created.');
     expect(exitSpy).toHaveBeenCalledWith(0);
 
     exitSpy.mockRestore();
+  });
+
+  it('accepts an initialValues object (no error thrown with object arg)', async () => {
+    p.group.mockResolvedValueOnce(mockValues);
+    await expect(promptUser({ projectName: 'init-name' })).resolves.toBeDefined();
+  });
+
+  it('passes initialValues.projectName as initialValue to the projectName prompt', async () => {
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      await fieldsObj.projectName();
+      return mockValues;
+    });
+    await promptUser({ projectName: 'pre-filled' });
+    expect(p.text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: 'pre-filled' })
+    );
+  });
+
+  it('passes initialValues.description as initialValue to the description prompt', async () => {
+    p.group.mockImplementationOnce(async (fieldsObj) => {
+      await fieldsObj.description();
+      return mockValues;
+    });
+    await promptUser({ description: 'pre-filled desc' });
+    expect(p.text).toHaveBeenCalledWith(
+      expect.objectContaining({ initialValue: 'pre-filled desc' })
+    );
   });
 });

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -59,8 +59,24 @@ describe('validateProjectName', () => {
     expect(validateProjectName('a')).toBeUndefined();
   });
 
-  it('returns undefined for an uppercase name (no case restriction in validation)', () => {
-    expect(validateProjectName('MyProject')).toBeUndefined();
+  it('rejects an uppercase name', () => {
+    expect(validateProjectName('MyProject')).toMatch(/lowercase/i);
+  });
+
+  it('rejects a name starting with a hyphen', () => {
+    expect(validateProjectName('-myproject')).toMatch(/invalid/i);
+  });
+
+  it('rejects a name starting with an underscore', () => {
+    expect(validateProjectName('_myproject')).toMatch(/invalid/i);
+  });
+
+  it('rejects a name longer than 214 characters', () => {
+    expect(validateProjectName('a'.repeat(215))).toMatch(/214/);
+  });
+
+  it('accepts a name exactly 214 characters long', () => {
+    expect(validateProjectName('a'.repeat(214))).toBeUndefined();
   });
 });
 

--- a/test/cli.test.js
+++ b/test/cli.test.js
@@ -75,6 +75,10 @@ describe('validateProjectName', () => {
     expect(validateProjectName('a'.repeat(215))).toMatch(/214/);
   });
 
+  it('accepts a name starting with a digit', () => {
+    expect(validateProjectName('1project')).toBeUndefined();
+  });
+
   it('accepts a name exactly 214 characters long', () => {
     expect(validateProjectName('a'.repeat(214))).toBeUndefined();
   });


### PR DESCRIPTION
## Summary

Scaffolder core improvements — three independent changes:

### A1 — Non-interactive / flag mode
- `--yes`/`-y`: skip all prompts; requires a positional project name; uses `--type` (default `web`), `--description`, and git config for author/email
- `--type`: pre-select project type (`web`, `wordpress`, `email`) — works in interactive (pre-fills prompt) and `--yes` mode
- `--description`: pre-fill or set description

### A2 — CLI hygiene
- `--version`/`-v`: print version and exit
- `--help`/`-h`: print usage summary and exit

### A3 — Validation
- `validateProjectName` now enforces npm package name rules: lowercase only, must start with a letter or number, max 214 characters
- `promptUser` updated to accept an `initialValues` object to pre-fill any prompt field

### Security
- `validateProjectName` is now called in `--yes` mode to prevent path traversal (`../evil --yes` is rejected)

## Changes

- `bin/create.js` — rewritten with `parseArgs` (Node 18+ built-in, zero new deps)
- `src/cli.js` — `validateProjectName` stricter rules; `promptUser` signature → `initialValues` object
- `test/cli.test.js` — updated + new npm-valid name tests (126 tests)
- `test/cli-prompt.test.js` — updated for new signature + pre-fill coverage (all fields)
- `test/bin.test.js` — structural checks for all new flags

## Test Results

138 tests, 0 skipped — `src/` coverage 100% lines/branches/functions/statements

## Version

`1.3.1` → `1.4.0` (minor — new flags)
