### PR TITLE
docs: clarify release process — tag + GitHub Release required to publish to npm

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -68,7 +68,12 @@ When editing files inside `templates/`:
 
 One permanent branch: `main`. All feature, fix, and chore branches target `main` via PR.
 Branch names: `feat/<issue>-description`, `fix/<issue>-description`, `chore/<description>`.
-Releases: tag `main` with `vX.Y.Z` — the publish workflow runs automatically.
+Releases: always do all three steps together when bumping `package.json` version:
+1. Merge the PR to `main`
+2. `git tag vX.Y.Z <merge-sha> && git push origin vX.Y.Z`
+3. `gh release create vX.Y.Z` — this triggers the publish workflow
+
+Skipping the tag or the GitHub Release means npm never receives the update.
 
 ## Commit Conventions
 - Prefix: `feat:`, `fix:`, `chore:`, `docs:`, `test:`, `ci:`, `security:` ([Conventional Commits](https://www.conventionalcommits.org/))

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -91,6 +91,13 @@ One permanent branch: **`main`** (the only long-lived branch).
 
 All PRs target `main`. Release tags on `main` trigger the npm publish pipeline.
 
+**Release process (mandatory — always do all three steps together):**
+1. Merge the PR to `main`
+2. Tag `main` at the merge commit: `git tag vX.Y.Z <sha> && git push origin vX.Y.Z`
+3. Publish a GitHub Release from that tag (`gh release create vX.Y.Z ...`) — this triggers the publish workflow
+
+Skipping step 2 or 3 means the npm package is never published. `package.json` version and the npm registry must always stay in sync.
+
 ---
 
 ## Key Commands


### PR DESCRIPTION
Root cause of v1.4.0 not publishing: the tag and GitHub Release were never created after merging the PR.

The publish workflow triggers on `release: types: [published]` — not on PR merge. The old docs only said "tag main with vX.Y.Z — the publish workflow runs automatically", which is technically correct but omits the GitHub Release step that actually triggers it.

## Changes

**`AGENTS.md`** and **`.github/copilot-instructions.md`**: replace the single-line release note with a numbered 3-step process:

1. Merge the PR to `main`
2. `git tag vX.Y.Z <merge-sha> && git push origin vX.Y.Z`
3. `gh release create vX.Y.Z` — this triggers the publish workflow

With an explicit note that skipping either step means npm never receives the update.
