### PR TITLE
chore: harden copilot-setup-steps workflow

### DIFF
--- a/.github/workflows/copilot-setup-steps.yml
+++ b/.github/workflows/copilot-setup-steps.yml
@@ -2,6 +2,9 @@ name: Copilot Setup Steps
 
 on: workflow_dispatch
 
+permissions:
+  contents: read
+
 jobs:
   copilot-setup-steps:
     name: Set up Copilot agent environment
@@ -18,4 +21,4 @@ jobs:
           cache: npm
 
       - name: Install dependencies
-        run: npm ci --ignore-scripts --legacy-peer-deps
+        run: npm ci --ignore-scripts


### PR DESCRIPTION
## What

Two small hardening fixes to `.github/workflows/copilot-setup-steps.yml`.

### Add explicit `permissions` block

Adds `permissions: contents: read` at the workflow level.

Fixes CodeQL alert [actions/missing-workflow-permissions (#2)](https://github.com/uncleSoWise/gulp-khup/security/code-scanning/2) — without an explicit block the workflow inherits whatever the repo/org default is, violating the principle of least privilege.

### Remove `--legacy-peer-deps`

No other workflow uses this flag and the current dependency tree has no peer conflicts, so it was dead weight. Aligns with the pattern in `ci.yml`.